### PR TITLE
Change master to develop in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,6 @@ Not all may apply:
 - [ ] No unexpected regression test changes
 - [ ] All tests are passing (green) on circleci
 - [ ] The [changelog](https://github.com/NREL/resstock/blob/master/CHANGELOG.md) has been updated appropriately
-- [ ] This branch is up-to-date with master
+- [ ] This branch is up-to-date with develop
 
 For more information on how to perform these checklist items, see the documentation's [Advanced Tutorial](https://resstock.readthedocs.io/en/latest/advanced_tutorial/index.html).


### PR DESCRIPTION
## Pull Request Description

The word **master** is still in the PR template. This PR is meant to change the wording to change it to **develop**.

## Checklist

Not all may apply:

- [ ] Unit tests have been added or updated
- [ ] All rake tasks have been run, and pass
- [ ] Documentation has been modified appropriately
- [ ] Any new options are added to `project_testing`
- [ ] `project_testing` runs without any failures
- [ ] No unexpected regression test changes
- [ ] All tests are passing (green) on circleci
- [ ] The [changelog](https://github.com/NREL/resstock/blob/master/CHANGELOG.md) has been updated appropriately
- [x] This branch is up-to-date with develop

For more information on how to perform these checklist items, see the documentation's [Advanced Tutorial](https://resstock.readthedocs.io/en/latest/advanced_tutorial/index.html).
