### PR TITLE
Change to UTC time calculations to avoid DST messing things up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Fixes
 - Fix for calculating door and below-grade wall area of multifamily and single-family attached buildings with collapsed geometries ([#523](https://github.com/NREL/resstock/pull/523))
 - In the Corridor.tsv, assign single-family attached, single-family detached, and mobile homes with a "Not Applicable" option ([#502](https://github.com/NREL/resstock/pull/522))
 - Remove ceiling fan energy for vacant units ([#527](https://github.com/NREL/resstock/pull/527))
+- Fix bug related to incorrect timestamps when using AMY weather file ([#528](https://github.com/NREL/resstock/pull/528)) 
 
 ## ResStock v2.3.0
 ###### June 24, 2020 - [Diff](https://github.com/NREL/resstock/compare/v2.2.4...v2.3.0)

--- a/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
+++ b/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
@@ -274,6 +274,23 @@ class TimeseriesCSVExportTest < MiniTest::Test
       timeseries_length, timeseries_width = get_enduse_timeseries(enduse_timeseries_path(test_name))
       assert_equal(expected_values["EnduseTimeseriesLength"], timeseries_length)
       assert_equal(expected_values["EnduseTimeseriesWidth"], timeseries_width)
+
+      # jumps are allowed in DST timestamps, but only twice at max, and each jump should be of 3600 seconds
+      salient_jumps = verify_uniform_timestamps(enduse_timeseries_path(test_name), 1, jumps_allowed = true)
+      # the jumps should cancel each other
+      assert_equal(0, salient_jumps.map{|x| x[1]}.reduce(0, :+))
+      if salient_jumps.length > 2
+        raise("DST timestamps should have a maximum of 2 jumps. It had #{salient_jumps.length} jumps at: #{salient_jumps}")
+      end
+      salient_jumps.each do |jump|
+        if jump[1].abs != 3600
+          raise("DST timestamps column has an invalid jump of #{jump[1]} seconds at #{jump[0]}")
+        end
+      end
+
+      verify_uniform_timestamps(enduse_timeseries_path(test_name), 0, jumps_allowed = false)
+      verify_uniform_timestamps(enduse_timeseries_path(test_name), 2, jumps_allowed = false)
+
     end
 
     # assert that it ran correctly
@@ -289,5 +306,50 @@ class TimeseriesCSVExportTest < MiniTest::Test
     cols = rows.transpose
     timeseries_width = cols.length
     return timeseries_length, timeseries_width
+  end
+
+  def to_utctime(datetimestr)
+    date, time = datetimestr.split(" ")
+    date_parts = date.split("/")
+    time_parts = time.split(":")
+    return Time.utc(*(date_parts + time_parts))
+  end
+
+  def verify_uniform_timestamps(enduse_timeseries, col_num, jumps_allowed = false)
+    # Verifies if timestamps are uniform. If they are not, it will raise an error if jumps_allowed = false.
+    # if jumps_allowed = true, instead of raising error, it returns an array that contains pair of timestamp and
+    # abnormal jumps.
+    rows = CSV.read(File.expand_path(enduse_timeseries))
+    header_row = rows[0]
+    if rows.length <= 2
+      return []
+    end
+    first_datetime = to_utctime(rows[1][col_num])
+    second_datetime = to_utctime(rows[2][col_num])
+    valid_diff = second_datetime - first_datetime # Assume the first diff is the valid one
+
+    if valid_diff >= 28*24*60*60 # diff is larger than 28 days; likely monthly timestamps
+      # The timestamps are likely in monthly interval. This function cannot test uniformity on such case so let it pass
+      # TODO: Test uniformity even in case of monthly timestamps
+      return []
+    end
+
+    salient_jumps = []
+    last_datetime = second_datetime
+    rows[3..-1].each do |entry|
+      current_datetime = to_utctime(entry[col_num])
+      current_diff = current_datetime - last_datetime
+      if current_diff != valid_diff
+        if not jumps_allowed
+          raise("Timestamps in #{header_row[col_num]} column in #{enduse_timeseries} not uniform. It jumped by #{current_diff} seconds at"\
+              " #{entry[0]}, while it has been jumping by #{last_diff} seconds before.")
+        else
+          extra_jump = current_diff - valid_diff
+          salient_jumps.push([current_datetime, extra_jump])
+        end
+      end
+      last_datetime = current_datetime
+    end
+    return salient_jumps
   end
 end

--- a/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
+++ b/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
@@ -278,10 +278,11 @@ class TimeseriesCSVExportTest < MiniTest::Test
       # jumps are allowed in DST timestamps, but only twice at max, and each jump should be of 3600 seconds
       salient_jumps = verify_uniform_timestamps(enduse_timeseries_path(test_name), 1, jumps_allowed = true)
       # the jumps should cancel each other
-      assert_equal(0, salient_jumps.map{|x| x[1]}.reduce(0, :+))
+      assert_equal(0, salient_jumps.map { |x| x[1] }.reduce(0, :+))
       if salient_jumps.length > 2
         raise("DST timestamps should have a maximum of 2 jumps. It had #{salient_jumps.length} jumps at: #{salient_jumps}")
       end
+
       salient_jumps.each do |jump|
         if jump[1].abs != 3600
           raise("DST timestamps column has an invalid jump of #{jump[1]} seconds at #{jump[0]}")
@@ -324,11 +325,12 @@ class TimeseriesCSVExportTest < MiniTest::Test
     if rows.length <= 2
       return []
     end
+
     first_datetime = to_utctime(rows[1][col_num])
     second_datetime = to_utctime(rows[2][col_num])
     valid_diff = second_datetime - first_datetime # Assume the first diff is the valid one
 
-    if valid_diff >= 28*24*60*60 # diff is larger than 28 days; likely monthly timestamps
+    if valid_diff >= 28 * 24 * 60 * 60 # diff is larger than 28 days; likely monthly timestamps
       # The timestamps are likely in monthly interval. This function cannot test uniformity on such case so let it pass
       # TODO: Test uniformity even in case of monthly timestamps
       return []

--- a/resources/measures/HPXMLtoOpenStudio/resources/weather.rb
+++ b/resources/measures/HPXMLtoOpenStudio/resources/weather.rb
@@ -120,15 +120,15 @@ class WeatherProcess
       is_leap_year = { true => 1, false => 0 }[@model.getYearDescription.isLeapYear]
 
       run_period = @model.getRunPeriod
-      start_time = Time.new(start_actual_year, run_period.getBeginMonth, run_period.getBeginDayOfMonth, 0, 1)
-      end_time = Time.new(end_actual_year, run_period.getEndMonth, run_period.getEndDayOfMonth, 24)
+      start_time = Time.utc(start_actual_year, run_period.getBeginMonth, run_period.getBeginDayOfMonth, 0, 1)
+      end_time = Time.utc(end_actual_year, run_period.getEndMonth, run_period.getEndDayOfMonth, 24)
 
       if reporting_frequency == "Timestep"
         tstep = @model.getTimestep.numberOfTimestepsPerHour
 
         unless run_period_control_daylight_saving_time.nil?
-          dst_start_ts = Time.new(dst_start_date.year, dst_start_date.monthOfYear.value, dst_start_date.dayOfMonth, dst_start_time.hours, dst_start_time.minutes)
-          dst_end_ts = Time.new(dst_end_date.year, dst_end_date.monthOfYear.value, dst_end_date.dayOfMonth, dst_end_time.hours, dst_end_time.minutes)
+          dst_start_ts = Time.utc(dst_start_date.year, dst_start_date.monthOfYear.value, dst_start_date.dayOfMonth, dst_start_time.hours, dst_start_time.minutes)
+          dst_end_ts = Time.utc(dst_end_date.year, dst_end_date.monthOfYear.value, dst_end_date.dayOfMonth, dst_end_time.hours, dst_end_time.minutes)
         end
 
         (start_actual_year..(end_actual_year + 1)).to_a.each do |year|
@@ -137,7 +137,7 @@ class WeatherProcess
             days.to_a.each do |day|
               (0..23).to_a.each do |hour|
                 (0..60 - (60 / tstep)).step(60 / tstep).to_a.each do |minute|
-                  ts = Time.new(year, month, day, hour, minute)
+                  ts = Time.utc(year, month, day, hour, minute)
                   next if ts < start_time or ts > end_time
 
                   timestamps << ts.strftime("%Y/%m/%d %H:%M:00")
@@ -157,8 +157,8 @@ class WeatherProcess
         end
       elsif reporting_frequency == "Hourly"
         unless run_period_control_daylight_saving_time.nil?
-          dst_start_ts = Time.new(dst_start_date.year, dst_start_date.monthOfYear.value, dst_start_date.dayOfMonth, dst_start_time.hours)
-          dst_end_ts = Time.new(dst_end_date.year, dst_end_date.monthOfYear.value, dst_end_date.dayOfMonth, dst_end_time.hours)
+          dst_start_ts = Time.utc(dst_start_date.year, dst_start_date.monthOfYear.value, dst_start_date.dayOfMonth, dst_start_time.hours)
+          dst_end_ts = Time.utc(dst_end_date.year, dst_end_date.monthOfYear.value, dst_end_date.dayOfMonth, dst_end_time.hours)
         end
 
         (start_actual_year..end_actual_year).to_a.each do |year|
@@ -166,7 +166,8 @@ class WeatherProcess
             days = get_days_for_month(month, is_leap_year)
             days.to_a.each do |day|
               (1..24).to_a.each do |hour|
-                ts = Time.new(year, month, day, hour)
+                ts = Time.utc(year, month, day, hour)
+
                 next if ts < start_time or ts > end_time
 
                 timestamps << ts.strftime("%Y/%m/%d %H:00:00")
@@ -186,15 +187,15 @@ class WeatherProcess
         end
       elsif reporting_frequency == "Daily"
         unless run_period_control_daylight_saving_time.nil?
-          dst_start_ts = Time.new(dst_start_date.year, dst_start_date.monthOfYear.value, dst_start_date.dayOfMonth)
-          dst_end_ts = Time.new(dst_end_date.year, dst_end_date.monthOfYear.value, dst_end_date.dayOfMonth)
+          dst_start_ts = Time.utc(dst_start_date.year, dst_start_date.monthOfYear.value, dst_start_date.dayOfMonth)
+          dst_end_ts = Time.utc(dst_end_date.year, dst_end_date.monthOfYear.value, dst_end_date.dayOfMonth)
         end
 
         (start_actual_year..end_actual_year + 1).to_a.each do |year|
           (1..12).to_a.each do |month|
             days = get_days_for_month(month, is_leap_year)
             days.to_a.each do |day|
-              ts = Time.new(year, month, day)
+              ts = Time.utc(year, month, day)
               next if ts < start_time or ts > end_time
 
               timestamps << ts.strftime("%Y/%m/%d 00:00:00")
@@ -212,13 +213,13 @@ class WeatherProcess
         end
       elsif reporting_frequency == "Monthly"
         unless run_period_control_daylight_saving_time.nil?
-          dst_start_ts = Time.new(dst_start_date.year, dst_start_date.monthOfYear.value)
-          dst_end_ts = Time.new(dst_end_date.year, dst_end_date.monthOfYear.value)
+          dst_start_ts = Time.utc(dst_start_date.year, dst_start_date.monthOfYear.value)
+          dst_end_ts = Time.utc(dst_end_date.year, dst_end_date.monthOfYear.value)
         end
 
         (start_actual_year..end_actual_year + 1).to_a.each do |year|
           (1..12).to_a.each do |month|
-            ts = Time.new(year, month)
+            ts = Time.utc(year, month)
             next if ts < start_time or ts > end_time
 
             timestamps << ts.strftime("%Y/%m/01 00:00:00")
@@ -235,11 +236,11 @@ class WeatherProcess
         end
       elsif reporting_frequency == "Runperiod"
         unless run_period_control_daylight_saving_time.nil?
-          dst_start_ts = Time.new(dst_start_date.year)
-          dst_end_ts = Time.new(dst_end_date.year)
+          dst_start_ts = Time.utc(dst_start_date.year)
+          dst_end_ts = Time.utc(dst_end_date.year)
         end
 
-        ts = Time.new(end_actual_year + 1)
+        ts = Time.utc(end_actual_year + 1)
         timestamps << ts.strftime("%Y/01/01 00:00:00")
         utc_timestamps << (ts - utc_offset_sec).strftime("%Y/%m/%d %H:%M:00")
         unless run_period_control_daylight_saving_time.nil?


### PR DESCRIPTION
Resolves the issue of timestamps being incorrect around the DST switchover time when using AMY weather files.

## Pull Request Description
Ruby resolves: `Time.new(2019,3,10,2,45,0)` into either `"2019-03-10 03:45:00 -0600"` or `"2019-03-10 02:45:00 -0700"` depending upon system timezone settings.  This fixes the issue by using utc timestamps for calculations so the local timezone settings doesn't interfere. 

## Checklist

Not all may apply:

- [x] Unit tests have been added or updated
- [x] All rake tasks have been run, and pass
- [ ] Documentation has been modified appropriately
- [ ] Any new options are added to `project_testing`
- [ ] `project_testing` runs without any failures
- [ ] No unexpected regression test changes
- [x] All tests are passing
- [x] The [changelog](https://github.com/NREL/resstock/blob/master/CHANGELOG.md) has been updated appropriately
- [x] This branch is up-to-date with develop

For more information on how to perform these checklist items, see the documentation's [Advanced Tutorial](https://resstock.readthedocs.io/en/latest/advanced_tutorial/index.html).
