### PR TITLE
ResStock-HPXML: Retain HVAC sizes

### DIFF
--- a/measures/ApplyUpgrade/measure.rb
+++ b/measures/ApplyUpgrade/measure.rb
@@ -117,6 +117,13 @@ class ApplyUpgrade < OpenStudio::Ruleset::ModelUserScript
     run_measure.setDefaultValue(1)
     args << run_measure
 
+    # Make bool arg to retain HVAC sizes
+    retain_hvac_sizes = OpenStudio::Ruleset::OSArgument::makeBoolArgument('retain_hvac_sizes', true)
+    retain_hvac_sizes.setDisplayName('Retain HVAC Sizes')
+    retain_hvac_sizes.setDescription('Whether to retain HVAC sizes.')
+    retain_hvac_sizes.setDefaultValue(true)
+    args << retain_hvac_sizes
+
     return args
   end
 
@@ -314,13 +321,50 @@ class ApplyUpgrade < OpenStudio::Ruleset::ModelUserScript
         measures['BuildResidentialHPXML'][0][step_value.name] = value
       end
 
+      measures['HPXMLtoOpenStudio'] = [{ 'hpxml_path' => File.expand_path('../upgraded.xml') }]
+
+      # Use generated schedules from the base building
       schedules_type = measures['BuildResidentialHPXML'][0]['schedules_type']
       if schedules_type == 'stochastic' # avoid re-running the stochastic schedule generator
         measures['BuildResidentialHPXML'][0]['schedules_type'] = 'user-specified'
         measures['BuildResidentialHPXML'][0]['schedules_path'] = File.expand_path('../schedules.csv')
       end
 
-      measures['HPXMLtoOpenStudio'] = [{ 'hpxml_path' => File.expand_path('../upgraded.xml') }]
+      # Retain HVAC sizes for non-HVAC upgrades
+      if runner.getBoolArgumentValue('retain_hvac_sizes', user_arguments)
+        hpxml_path = File.expand_path('../in.xml') # this is the defaulted hpxml
+        hpxml = HPXML.new(hpxml_path: hpxml_path)
+
+        heating_systems = {}
+        hpxml.heating_systems.each do |heating_system|
+          heating_systems[heating_system] = heating_system.fraction_heat_load_served
+        end
+
+        if heating_systems.size == 1
+          # measures['BuildResidentialHPXML'][0]['heating_system_heating_capacity'] = heating_systems[0].heating_capacity
+          measures['BuildResidentialHPXML'][0]['heating_system_heating_capacity'] = 6000.0
+        elsif heating_systems.size == 2
+          heating_systems = heating_systems.sort_by { |k, v| v } # sort smallest frac to largest frac
+          # measures['BuildResidentialHPXML'][0]['heating_system_heating_capacity_2'] = heating_systems[0].heating_capacity
+          # measures['BuildResidentialHPXML'][0]['heating_system_heating_capacity'] = heating_systems[1].heating_capacity
+          measures['BuildResidentialHPXML'][0]['heating_system_heating_capacity_2'] = 5000.0
+          measures['BuildResidentialHPXML'][0]['heating_system_heating_capacity'] = 1000.0
+        end
+
+        hpxml.cooling_systems.each do |cooling_system|
+          # measures['BuildResidentialHPXML'][0]['cooling_system_cooling_capacity'] = cooling_system.cooling_capacity
+          measures['BuildResidentialHPXML'][0]['cooling_system_cooling_capacity'] = 5000.0
+        end
+
+        hpxml.heat_pumps.each do |heat_pump|
+          # measures['BuildResidentialHPXML'][0]['heat_pump_heating_capacity'] = heat_pump.heating_capacity
+          # measures['BuildResidentialHPXML'][0]['heat_pump_cooling_capacity'] = heat_pump.cooling_capacity
+          # measures['BuildResidentialHPXML'][0]['heat_pump_backup_heating_capacity'] = heat_pump.backup_heating_capacity
+          measures['BuildResidentialHPXML'][0]['heat_pump_heating_capacity'] = 2500.0
+          measures['BuildResidentialHPXML'][0]['heat_pump_cooling_capacity'] = 2500.0
+          measures['BuildResidentialHPXML'][0]['heat_pump_backup_heating_capacity'] = 2000.0
+        end
+      end
 
       # Get software program used and version
       measures['BuildResidentialHPXML'][0]['software_program_used'] = software_program_used

--- a/measures/ApplyUpgrade/measure.xml
+++ b/measures/ApplyUpgrade/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>apply_upgrade</name>
   <uid>33f1654c-f734-43d1-b35d-9d2856e41b5a</uid>
-  <version_id>fcd75ab9-0b33-4889-86b0-1098f6cac970</version_id>
-  <version_modified>20210104T215257Z</version_modified>
+  <version_id>86af843a-ace3-4964-b445-2e8433d5638f</version_id>
+  <version_modified>20210127T231558Z</version_modified>
   <xml_checksum>9339BE01</xml_checksum>
   <class_name>ApplyUpgrade</class_name>
   <display_name>Apply Upgrade</display_name>
@@ -4662,6 +4662,25 @@
       <model_dependent>false</model_dependent>
       <default_value>1</default_value>
     </argument>
+    <argument>
+      <name>retain_hvac_sizes</name>
+      <display_name>Retain HVAC Sizes</display_name>
+      <description>Whether to retain HVAC sizes.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>true</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
   </arguments>
   <outputs />
   <provenances />
@@ -4722,6 +4741,12 @@
   </attributes>
   <files>
     <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>0E73294E</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>1.9.0</identifier>
@@ -4730,13 +4755,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>F4096911</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>0E73294E</checksum>
+      <checksum>9B5551E2</checksum>
     </file>
   </files>
 </measure>

--- a/measures/BuildExistingModel/measure.rb
+++ b/measures/BuildExistingModel/measure.rb
@@ -225,7 +225,7 @@ class BuildExistingModel < OpenStudio::Measure::ModelMeasure
       measures['BuildResidentialHPXML'][0][step_value.name] = value
     end
 
-    measures['HPXMLtoOpenStudio'] = [{ 'hpxml_path' => File.expand_path('../existing.xml') }]
+    measures['HPXMLtoOpenStudio'] = [{ 'hpxml_path' => File.expand_path('../existing.xml'), 'output_dir' => File.expand_path('..'), 'debug' => true }]
 
     # Get software program used and version
     measures['BuildResidentialHPXML'][0]['software_program_used'] = software_program_used

--- a/measures/BuildExistingModel/measure.xml
+++ b/measures/BuildExistingModel/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_existing_model</name>
   <uid>dedf59bb-3b88-4f16-8755-2c1ff5519cbf</uid>
-  <version_id>eca70f4e-56e4-46be-b7be-0d586358c6af</version_id>
-  <version_modified>20210104T215257Z</version_modified>
+  <version_id>58af06cc-769c-4fd3-aa56-f90363807a5e</version_id>
+  <version_modified>20210127T231558Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildExistingModel</class_name>
   <display_name>Build Existing Model</display_name>
@@ -136,7 +136,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>AC63D537</checksum>
+      <checksum>797198DB</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
## Pull Request Description

Add new bool argument `retain_hvac_sizes` to `ApplyUpgrade` measure. Argument is `true` by default (i.e., most upgrades would not be HVAC-related). If `true`, we get HVAC capacities from `in.xml` and pass them into the second (upgrade) instance of `BuildResidentialHPXML`. In that way, we've retained HVAC sizes from the existing building.

## Checklist

Not all may apply:

- [ ] Unit tests have been added or updated
- [ ] All rake tasks have been run, and pass
- [ ] Documentation has been modified appropriately
- [ ] Any new options are added to `project_testing`
- [ ] `project_testing` runs without any failures
- [ ] No unexpected regression test changes
- [ ] All tests are passing
- [ ] The [changelog](https://github.com/NREL/resstock/blob/master/CHANGELOG.md) has been updated appropriately
- [ ] This branch is up-to-date with develop

For more information on how to perform these checklist items, see the documentation's [Advanced Tutorial](https://resstock.readthedocs.io/en/latest/advanced_tutorial/index.html).
