### PR TITLE
Speed up TSV fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Features
 
 - Model multifamily and single-family attached buildings as individual dwelling units ([#439](https://github.com/NREL/resstock/pull/439))
 
+Fixes
+- Fixes significant runtime bottleneck in TSV fetching in BuildExistingModel & ApplyUpgrade measures ([#543](https://github.com/NREL/resstock/pull/543))
+
 ## ResStock v2.4.0
 
 ###### January 27, 2021 - [Diff](https://github.com/NREL/OpenStudio-BuildStock/compare/v2.3.0...v2.4.0)

--- a/resources/buildstock.rb
+++ b/resources/buildstock.rb
@@ -317,7 +317,7 @@ def get_measure_args_from_option_names(lookup_file, option_names, parameter_name
         options_measure_args[current_option][measure_dir] = args
       end
     else
-      break if found_options.all? { |elem| elem == true }
+      break if found_options.values.all? { |elem| elem == true }
     end
   end
   option_names.each do |option_name|


### PR DESCRIPTION
## Pull Request Description

A bug in the buildstock.rb `get_measure_args_from_option_names()` method was causing the entirety of every TSV to be processed even when the option(s) of interest had already been found. As the number and length of TSVs has grown, so has this bottleneck.

The bug causes both the BuildExistingModel and ApplyUpgrade measures to be far slower than they should be.

Time spent inside the method when running the first building w/ an upgrade from test_measures_osw.rb:
- `develop` branch: 62.7 seconds => 6.7 seconds
- `restructure-v3` branch: 38.5 seconds => 3.4 seconds

## Checklist

Not all may apply:

- [ ] Unit tests have been added or updated
- [ ] All rake tasks have been run, and pass
- [ ] Documentation has been modified appropriately
- [ ] Any new options are added to `project_testing`
- [ ] `project_testing` runs without any failures
- [ ] No unexpected regression test changes
- [x] All tests are passing
- [x] The [changelog](https://github.com/NREL/resstock/blob/master/CHANGELOG.md) has been updated appropriately
- [x] This branch is up-to-date with develop

For more information on how to perform these checklist items, see the documentation's [Advanced Tutorial](https://resstock.readthedocs.io/en/latest/advanced_tutorial/index.html).
