### PR TITLE
Correct number of sink DHW draw clusters per occupant

### DIFF
--- a/resources/measures/HPXMLtoOpenStudio/resources/schedules/schedule_config.yml
+++ b/resources/measures/HPXMLtoOpenStudio/resources/schedules/schedule_config.yml
@@ -41,7 +41,7 @@ sink:
   duration_probability: [0.901242, 0.076572, 0.01722, 0.003798, 0.000944, 0.000154, 4.6e-05, 2.2e-05, 2.0e-06]
   events_per_cluster_probs: [0.62458, 0.18693, 0.08011, 0.04330, 0.02178, 0.01504, 0.00830, 0.00467, 0.00570, 0.00285, 0.00181, 0.00233, 0.00130, 0.00104, 0.00026]
   hourly_onset_prob: [0.007, 0.018, 0.042, 0.062, 0.066, 0.062, 0.054, 0.050, 0.049, 0.045, 0.041, 0.043, 0.048, 0.065, 0.075, 0.069, 0.057, 0.048, 0.040, 0.027, 0.014, 0.007, 0.005, 0.005]
-  total_annual_cluster: 6000
+  total_annual_cluster: 2631 # For U.S. average of 2.53 occupants per household, based on relationship of 6885 clusters for 25 gpd, from Building America DHW Event Schedule Generator
   between_event_gap: 2  # in minutes
   flow_rate_mean: 1.14
   flow_rate_std: 0.61


### PR DESCRIPTION
Resolves #569 

## Pull Request Description

Correct number of sink DHW draw clusters per occupant. Changing to 2631 would be the easy fix. ~~Alternatively, we could use an equation for sink clusters per occupant:~~

~~# Based on 6885 clusters for 25 gpd, from Building America DHW Event Schedule Generator~~
~~sink clusters per occupant = (1941.8 * N_occ + 1753.1)/N_occ~~

*Edit: see pseudocode at https://github.com/NREL/resstock/issues/569 for the equations we want to implement.*

If we wanted to use sink usage multipliers, we could even scale the number of clusters by the multiplier to get more usage diversity.

## Checklist

Not all may apply:

- [ ] Unit tests have been added or updated
- [ ] All rake tasks have been run, and pass
- [ ] Documentation has been modified appropriately
- [ ] Any new options are added to `project_testing`
- [ ] `project_testing` runs without any failures
- [ ] No unexpected regression test changes
- [ ] All tests are passing
- [ ] The [changelog](https://github.com/NREL/resstock/blob/master/CHANGELOG.md) has been updated appropriately
- [ ] This branch is up-to-date with develop

For more information on how to perform these checklist items, see the documentation's [Advanced Tutorial](https://resstock.readthedocs.io/en/latest/advanced_tutorial/index.html).
