### PR TITLE
Faster stochastic schedules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Fixes
 - Reverses the material layers of the unfinished attic floor construction so that they are correctly ordered outside-to-inside ([#556](https://github.com/NREL/resstock/pull/556))
 - Fixes invalid garage and living space dimension errors ([#560](https://github.com/NREL/resstock/pull/560))
 - Set all mini-split heat pump supplemental capacity to autosize ([#564](https://github.com/NREL/resstock/pull/564))
+- Reduce stochastic schedule generation runtime by over 50% ([#571](https://github.com/NREL/resstock/pull/571))
 
 ## ResStock v2.4.0
 

--- a/resources/measures/HPXMLtoOpenStudio/resources/schedules.rb
+++ b/resources/measures/HPXMLtoOpenStudio/resources/schedules.rb
@@ -1566,10 +1566,11 @@ class ScheduleGenerator
   end
 
   def apply_monthly_offsets(array)
+    month_strs = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'July', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+    new_array = []
     @total_days_in_year.times do |day|
       today = @sim_start_day + day
       day_of_week = today.wday
-      month_strs = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'July', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
       month = month_strs[today.month - 1]
       if [0, 6].include?(day_of_week)
         # Weekend
@@ -1582,9 +1583,9 @@ class ScheduleGenerator
         raise "Could not find the entry for month #{month}, day #{day_of_week} and state #{@state}"
       end
 
-      array[day * 1440, 1440] = array[day * 1440, 1440].rotate(lead)
+      new_array << array[day * 1440, 1440].rotate(lead)
     end
-    return array
+    return new_array.flatten!
   end
 
   def read_monthly_shift_minutes(daytype)


### PR DESCRIPTION
Resolves #[issue number here].

## Pull Request Description

Related to https://github.com/NREL/OpenStudio-HPXML/pull/697.

`ScheduleGenerator.create`:
* `develop`: ~34 s
* `faster-schedules`: ~10 s

Great one-liner improvement, @shorowit!

## Checklist

Not all may apply:

- [ ] Unit tests have been added or updated
- [ ] All rake tasks have been run, and pass
- [ ] Documentation has been modified appropriately
- [ ] Any new options are added to `project_testing`
- [ ] `project_testing` runs without any failures
- [ ] No unexpected regression test changes
- [ ] All tests are passing
- [ ] The [changelog](https://github.com/NREL/resstock/blob/master/CHANGELOG.md) has been updated appropriately
- [ ] This branch is up-to-date with develop

For more information on how to perform these checklist items, see the documentation's [Advanced Tutorial](https://resstock.readthedocs.io/en/latest/advanced_tutorial/index.html).
