### PR TITLE
Fix for misc loads

### DIFF
--- a/resources/measures/ResidentialMiscLargeUncommonLoads/measure.rb
+++ b/resources/measures/ResidentialMiscLargeUncommonLoads/measure.rb
@@ -818,6 +818,7 @@ class ResidentialMiscLargeUncommonLoads < OpenStudio::Measure::ModelMeasure
           tot_ann_e += ann_e
         end
 
+        schedules_file.set_vacancy(col_name: "plug_loads_well_pump")
       end
 
       # Gas Fireplace
@@ -841,6 +842,7 @@ class ResidentialMiscLargeUncommonLoads < OpenStudio::Measure::ModelMeasure
 
         end
 
+        schedules_file.set_vacancy(col_name: "fuel_loads_fireplace")
       end
 
       # Gas Grill
@@ -859,6 +861,7 @@ class ResidentialMiscLargeUncommonLoads < OpenStudio::Measure::ModelMeasure
           tot_ann_g += ann_g
         end
 
+        schedules_file.set_vacancy(col_name: "fuel_loads_grill")
       end
 
       # Gas Lighting
@@ -877,6 +880,7 @@ class ResidentialMiscLargeUncommonLoads < OpenStudio::Measure::ModelMeasure
           tot_ann_g += ann_g
         end
 
+        schedules_file.set_vacancy(col_name: "fuel_loads_lighting")
       end
 
       # Electric Vehicle
@@ -895,14 +899,9 @@ class ResidentialMiscLargeUncommonLoads < OpenStudio::Measure::ModelMeasure
           tot_ann_e += ann_e
         end
 
+        schedules_file.set_vacancy(col_name: "plug_loads_vehicle")
       end
     end
-
-    schedules_file.set_vacancy(col_name: "plug_loads_vehicle")
-    schedules_file.set_vacancy(col_name: "plug_loads_well_pump")
-    schedules_file.set_vacancy(col_name: "fuel_loads_grill")
-    schedules_file.set_vacancy(col_name: "fuel_loads_lighting")
-    schedules_file.set_vacancy(col_name: "fuel_loads_fireplace")
 
     # Reporting
     if msgs.size > 1


### PR DESCRIPTION
Resolves #[issue number here].

## Pull Request Description

Fix for https://github.com/NREL/resstock/pull/566, only call `set_vacancy(...)` if the misc load exists.

## Checklist

Not all may apply:

- [ ] Unit tests have been added or updated
- [ ] All rake tasks have been run, and pass
- [ ] Documentation has been modified appropriately
- [ ] Any new options are added to `project_testing`
- [ ] `project_testing` runs without any failures
- [ ] No unexpected regression test changes
- [ ] All tests are passing
- [ ] The [changelog](https://github.com/NREL/resstock/blob/master/CHANGELOG.md) has been updated appropriately
- [ ] This branch is up-to-date with develop

For more information on how to perform these checklist items, see the documentation's [Advanced Tutorial](https://resstock.readthedocs.io/en/latest/advanced_tutorial/index.html).
