### PR TITLE
Fix old docs path

### DIFF
--- a/docs/read_the_docs/source/advanced_tutorial/increasing_upgrade_options.rst
+++ b/docs/read_the_docs/source/advanced_tutorial/increasing_upgrade_options.rst
@@ -1,7 +1,7 @@
 Increasing Upgrade Options
 ==========================
 
-To allow more options per upgrade, increase the value returned by the following method defined in ``resources/measures/HPXMLtoOpenStudio/resources/constants.rb``:
+To allow more options per upgrade, increase the value returned by the following method defined in ``measures/ApplyUpgrade/resources/constants.rb``:
 
 .. code::
 


### PR DESCRIPTION
## Pull Request Description

`self.NumApplyUpgradeOptions` is found in `measures/ApplyUpgrade/resources/constants.rb`, not `resources/measures/HPXMLtoOpenStudio/resources/constants.rb`.

## Checklist

Not all may apply:

- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
