### PR TITLE
Bugfix: Incorrect wall assembly R-values

### DIFF
--- a/resources/options_lookup.tsv
+++ b/resources/options_lookup.tsv
@@ -385,16 +385,16 @@ Insulation Wall	"Wood Stud, R-19, Grade 2"	ResStockArguments	wall_type=WoodStud	
 Insulation Wall	"Wood Stud, R-19, Grade 3"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=13.4																							
 Insulation Wall	"Wood Stud, R-23 Closed Cell Spray Foam, 2x4, 16 in o.c."	ResStockArguments	wall_type=WoodStud	wall_assembly_r=14.7																							
 Insulation Wall	"Wood Stud, R-36"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=22.3																							
-Insulation Wall	"Wood Stud, Uninsulated, R-5 Sheathing"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=8.6																							
-Insulation Wall	"Wood Stud, R-7, R-5 Sheathing"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=14.6																							
-Insulation Wall	"Wood Stud, R-11, R-5 Sheathing"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=13.8																							
-Insulation Wall	"Wood Stud, R-13, R-5 Sheathing"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=16.8																							
-Insulation Wall	"Wood Stud, R-15, R-5 Sheathing"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=17.8																							
-Insulation Wall	"Wood Stud, R-19, R-5 Sheathing"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=21.8																							
-Insulation Wall	"Wood Stud, R-19, Grade 2, R-5 Sheathing"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=21.2																							
-Insulation Wall	"Wood Stud, R-19, Grade 3, R-5 Sheathing"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=20.3																							
-Insulation Wall	"Wood Stud, R-23 Closed Cell Spray Foam, 2x4, 16 in o.c., R-5 Sheathing"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=21.3																							
-Insulation Wall	"Wood Stud, R-36, R-5 Sheathing"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=29.5																							
+Insulation Wall	"Wood Stud, Uninsulated, R-5 Sheathing"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=8.4																							
+Insulation Wall	"Wood Stud, R-7, R-5 Sheathing"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=13.7																							
+Insulation Wall	"Wood Stud, R-11, R-5 Sheathing"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=15.3																							
+Insulation Wall	"Wood Stud, R-13, R-5 Sheathing"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=16.3																							
+Insulation Wall	"Wood Stud, R-15, R-5 Sheathing"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=17.1																							
+Insulation Wall	"Wood Stud, R-19, R-5 Sheathing"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=20.4																							
+Insulation Wall	"Wood Stud, R-19, Grade 2, R-5 Sheathing"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=19.5																							
+Insulation Wall	"Wood Stud, R-19, Grade 3, R-5 Sheathing"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=18.4																							
+Insulation Wall	"Wood Stud, R-23 Closed Cell Spray Foam, 2x4, 16 in o.c., R-5 Sheathing"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=19.7																							
+Insulation Wall	"Wood Stud, R-36, R-5 Sheathing"	ResStockArguments	wall_type=WoodStud	wall_assembly_r=27.3																							
 Insulation Wall	"Double Wood Stud, R-33"	ResStockArguments	wall_type=DoubleWoodStud	wall_assembly_r=28.1																							
 Insulation Wall	"Double Wood Stud, R-45, Grade 3"	ResStockArguments	wall_type=DoubleWoodStud	wall_assembly_r=25.1																							
 Insulation Wall	"Steel Stud, Uninsulated"	ResStockArguments	wall_type=SteelFrame	wall_assembly_r=3																							


### PR DESCRIPTION
Resolves https://github.com/NREL/resstock/issues/893

## Pull Request Description

Assembly R values for wall options with R-5 exterior insulation have been corrected so that they are exactly +5 greater than their base wall assembly (those without continuous insulation).

## Checklist

Not all may apply:

- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
