### PR TITLE
run_analysis.rb option to preserve lib folder

### DIFF
--- a/workflow/run_analysis.rb
+++ b/workflow/run_analysis.rb
@@ -339,7 +339,7 @@ def run_workflow(yml, n_threads, measures_only, debug, building_ids, keep_run_fo
     end
   end
 
-  FileUtils.rm_rf(lib_dir)
+  FileUtils.rm_rf(lib_dir) if !debug
 
   return true
 end
@@ -371,7 +371,6 @@ end
 
 def samples_osw(results_dir, upgrade_name, workflow, building_id, job_id, folder_id, all_results_output, all_cli_output, measures, reporting_measures, measures_only, debug)
   scenario_osw_dir = File.join(results_dir, 'osw', upgrade_name)
-
   scenario_xml_dir = File.join(results_dir, 'xml', upgrade_name)
 
   worker_folder = "run#{folder_id}"
@@ -512,7 +511,7 @@ OptionParser.new do |opts|
   end
 
   options[:debug] = false
-  opts.on('-d', '--debug', 'Save both existing and upgraded xml/osw files') do |_t|
+  opts.on('-d', '--debug', 'Preserve lib folder and "existing" xml/osw files') do |_t|
     options[:debug] = true
   end
 


### PR DESCRIPTION
## Pull Request Description

Facilitates debugging by allowing datapoint run folder OSW files to be run manually.

## Checklist

Not all may apply:

- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
