### PR TITLE
Bump OS version to 3.5.1 and remove file cleanup workaround

### DIFF
--- a/resources/hpxml-measures/HPXMLtoOpenStudio/resources/version.rb
+++ b/resources/hpxml-measures/HPXMLtoOpenStudio/resources/version.rb
@@ -2,7 +2,7 @@
 
 class Version
   OS_HPXML_Version = '1.5.1' # Version of the OS-HPXML workflow
-  OS_Version = '3.5' # Required version of OpenStudio (can be 'X.X' or 'X.X.X')
+  OS_Version = '3.5.1' # Required version of OpenStudio (can be 'X.X' or 'X.X.X')
   HPXML_Version = '4.0' # HPXML schemaVersion
 
   def self.check_openstudio_version

--- a/resources/hpxml-measures/HPXMLtoOpenStudio/resources/xmlvalidator.rb
+++ b/resources/hpxml-measures/HPXMLtoOpenStudio/resources/xmlvalidator.rb
@@ -62,21 +62,6 @@ class XMLValidator
         end
       end
     end
-    cleanup_openstudio_tmp_dir(validator, schematron_path)
     return errors, warnings
-  end
-
-  def self.cleanup_openstudio_tmp_dir(validator, schema_path)
-    # Workaround for https://github.com/NREL/OpenStudio/issues/4761
-    # Remove this method if the issue is addressed
-    if validator.schemaPath.to_s != schema_path
-      # OpenStudio created a temp dir; delete it now
-      tmp_path = File.dirname(validator.schemaPath.to_s)
-      require 'fileutils'
-      begin
-        FileUtils.rm_r(tmp_path)
-      rescue
-      end
-    end
   end
 end


### PR DESCRIPTION
## Pull Request Description

Fixes https://github.com/NREL/resstock/issues/1035

Bump OS version to 3.5.1 and remove file cleanup workaround. The original file cleanup issue (https://github.com/NREL/OpenStudio/issues/4761) was fixed in Open Studio by https://github.com/NREL/OpenStudio/pull/4762 and released in OS 3.5.1.

## Checklist

Not all may apply:

- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
