### PR TITLE
Add capacity retention arguments for ASHP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Features
 - Demonstrate new power outage modeling feature using upgrades specified in example project yml files ([#1054](https://github.com/NREL/resstock/pull/1054))
 - Ability to specify a "sample_weight" column in the precomputed buildstock.csv ([#1056](https://github.com/NREL/resstock/pull/1056))
 - Add descriptions to the housing characteristics ([#1069](https://github.com/NREL/resstock/pull/1069))
+- Connect ASHP to optional capacity retention temperature and fraction arguments (that already exist for MSHP) ([#1071](https://github.com/NREL/resstock/pull/1071))
 
 Fixes
 - Pulls in upstream OS-HPXML fix related to [avoiding possible OpenStudio temporary directory collision](https://github.com/NREL/OpenStudio-HPXML/pull/1316) causing random errors ([#1054](https://github.com/NREL/resstock/pull/1054))

--- a/resources/hpxml-measures/BuildResidentialHPXML/measure.rb
+++ b/resources/hpxml-measures/BuildResidentialHPXML/measure.rb
@@ -1337,13 +1337,13 @@ class BuildResidentialHPXML < OpenStudio::Measure::ModelMeasure
 
     arg = OpenStudio::Measure::OSArgument::makeDoubleArgument('heat_pump_capacity_retention_fraction', false)
     arg.setDisplayName('Heat Pump: Capacity Retention Fraction')
-    arg.setDescription("Only used for #{HPXML::HVACTypeHeatPumpMiniSplit}.")
+    arg.setDescription("Only used for #{HPXML::HVACTypeHeatPumpAirToAir} and #{HPXML::HVACTypeHeatPumpMiniSplit}.")
     arg.setUnits('Frac')
     args << arg
 
     arg = OpenStudio::Measure::OSArgument::makeDoubleArgument('heat_pump_capacity_retention_temp', false)
     arg.setDisplayName('Heat Pump: Capacity Retention Temperature')
-    arg.setDescription("Only used for #{HPXML::HVACTypeHeatPumpMiniSplit}.")
+    arg.setDescription("Only used for #{HPXML::HVACTypeHeatPumpAirToAir} and #{HPXML::HVACTypeHeatPumpMiniSplit}.")
     arg.setUnits('deg-F')
     args << arg
 

--- a/resources/hpxml-measures/HPXMLtoOpenStudio/resources/hvac.rb
+++ b/resources/hpxml-measures/HPXMLtoOpenStudio/resources/hvac.rb
@@ -1102,10 +1102,11 @@ class HVAC
       cap_fflow_spec, eir_fflow_spec = get_airflow_fault_heating_coeff()
       hp_ap.heat_cap_fflow_spec = [cap_fflow_spec]
       hp_ap.heat_eir_fflow_spec = [eir_fflow_spec]
-      if heat_pump.heating_capacity_17F.nil?
-        hp_ap.heat_cap_ft_spec = [[0.566333415, -0.000744164, -0.0000103, 0.009414634, 0.0000506, -0.00000675]]
-      else
+
+      if !heat_pump.heating_capacity_17F.nil? || (!heat_pump.capacity_retention_temp.nil? && !heat_pump.capacity_retention_fraction.nil?)
         hp_ap.heat_cap_ft_spec = calc_heat_cap_ft_spec_using_capacity_17F(heat_pump)
+      else
+        hp_ap.heat_cap_ft_spec = [[0.566333415, -0.000744164, -0.0000103, 0.009414634, 0.0000506, -0.00000675]]
       end
       if not use_cop
         hp_ap.heat_cops = [calc_cop_heating_1speed(heat_pump.heating_efficiency_hspf, hp_ap.heat_c_d, hp_ap.fan_power_rated, hp_ap.heat_eir_ft_spec, hp_ap.heat_cap_ft_spec)]
@@ -1122,11 +1123,11 @@ class HVAC
                                    [0.76634609, 0.32840943, -0.094701495]]
       hp_ap.heat_eir_fflow_spec = [[2.153618211, -1.737190609, 0.584269478],
                                    [2.001041353, -1.58869128, 0.587593517]]
-      if heat_pump.heating_capacity_17F.nil?
+      if !heat_pump.heating_capacity_17F.nil? || (!heat_pump.capacity_retention_temp.nil? && !heat_pump.capacity_retention_fraction.nil?)
+        hp_ap.heat_cap_ft_spec = calc_heat_cap_ft_spec_using_capacity_17F(heat_pump)
+      else
         hp_ap.heat_cap_ft_spec = [[0.335690634, 0.002405123, -0.0000464, 0.013498735, 0.0000499, -0.00000725],
                                   [0.306358843, 0.005376987, -0.0000579, 0.011645092, 0.0000591, -0.0000203]]
-      else
-        hp_ap.heat_cap_ft_spec = calc_heat_cap_ft_spec_using_capacity_17F(heat_pump)
       end
       hp_ap.heat_cops = calc_cops_heating_2speed(heat_pump.heating_efficiency_hspf, hp_ap.heat_c_d, hp_ap.heat_capacity_ratios, hp_ap.heat_fan_speed_ratios, hp_ap.fan_power_rated, hp_ap.heat_eir_ft_spec, hp_ap.heat_cap_ft_spec)
     elsif hp_ap.num_speeds == 4
@@ -1140,13 +1141,13 @@ class HVAC
                                 [0.690404655, 0.00616619, 0.000137643, -0.009350199, 0.000153427, -0.000213258]]
       hp_ap.heat_cap_fflow_spec = [[1, 0, 0]] * 4
       hp_ap.heat_eir_fflow_spec = [[1, 0, 0]] * 4
-      if heat_pump.heating_capacity_17F.nil?
+      if !heat_pump.heating_capacity_17F.nil? || (!heat_pump.capacity_retention_temp.nil? && !heat_pump.capacity_retention_fraction.nil?)
+        hp_ap.heat_cap_ft_spec = calc_heat_cap_ft_spec_using_capacity_17F(heat_pump)
+      else
         hp_ap.heat_cap_ft_spec = [[0.304192655, -0.003972566, 0.0000196432, 0.024471251, -0.000000774126, -0.0000841323],
                                   [0.496381324, -0.00144792, 0.0, 0.016020855, 0.0000203447, -0.0000584118],
                                   [0.697171186, -0.006189599, 0.0000337077, 0.014291981, 0.0000105633, -0.0000387956],
                                   [0.555513805, -0.001337363, -0.00000265117, 0.014328826, 0.0000163849, -0.0000480711]]
-      else
-        hp_ap.heat_cap_ft_spec = calc_heat_cap_ft_spec_using_capacity_17F(heat_pump)
       end
       hp_ap.heat_cops = calc_cops_heating_4speed(heat_pump.heating_efficiency_hspf, hp_ap.heat_c_d, hp_ap.heat_capacity_ratios, hp_ap.heat_fan_speed_ratios, hp_ap.fan_power_rated, hp_ap.heat_eir_ft_spec, hp_ap.heat_cap_ft_spec)
     end
@@ -1860,10 +1861,12 @@ class HVAC
     # Derive coefficients from user input for heating capacity at 47F and 17F
     # Biquadratic: capacity multiplier = a + b*IAT + c*IAT^2 + d*OAT + e*OAT^2 + f*IAT*OAT
     x_A = 17.0
-    if heat_pump.heating_capacity > 0
+    y_A = 0.5 # Arbitrary
+    if !heat_pump.capacity_retention_temp.nil? && !heat_pump.capacity_retention_fraction.nil?
+      x_A = heat_pump.capacity_retention_temp # deg-F
+      y_A = heat_pump.capacity_retention_fraction # frac
+    elsif heat_pump.heating_capacity > 0
       y_A = heat_pump.heating_capacity_17F / heat_pump.heating_capacity
-    else
-      y_A = 0.5 # Arbitrary
     end
     x_B = 47.0 # 47F is the rating point
     y_B = 1.0


### PR DESCRIPTION
## Pull Request Description

Similar to https://github.com/NREL/resstock/pull/898, but for ASHP.

I tested this by (temporarily) adding a new option in the lookup that sets values for `heat_pump_capacity_retention_temp` and `heat_pump_capacity_retention_fraction`. Then in `national_upgrades.yml` I created a new upgrade that sets the new option. When I run `run_analysis.rb` for a datapoint (with the same base ASHP), I can see that the IDF files differ by their (1) Gross Rated Heating COP and (2) "Heat-CAP-fT1" biquadratic curve:

![image](https://user-images.githubusercontent.com/8516790/236952189-6b4c4c83-5924-4758-8c0c-f6e6fb3383a7.png)
![image](https://user-images.githubusercontent.com/8516790/236952244-bc06bf9b-d8ef-4fdf-82fd-a09b2b408c15.png)

## Checklist

Not all may apply:

- [ ] ~Tests (and test files) have been updated~
- [ ] ~Documentation has been updated~
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI (checked comparison artifacts)
