### PR TITLE
Misc config and test file updates

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -110,6 +110,9 @@ jobs:
 
       - name: Run tests
         run: |
+          sudo gem install minitest-reporters
+          sudo gem install simplecov
+          sudo gem install simplecov-html
           ruby test/test_bsb_analysis.rb
 
       - name: Upload integration results
@@ -152,6 +155,9 @@ jobs:
 
       - name: Run tests
         run: |
+          sudo gem install minitest-reporters
+          sudo gem install simplecov
+          sudo gem install simplecov-html
           ruby test/test_analysis_tools.rb
 
   compare-results:

--- a/measures/UpgradeCosts/measure.xml
+++ b/measures/UpgradeCosts/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>upgrade_costs</name>
   <uid>ef51212c-acc4-48d7-9b29-cf2a5c6c4449</uid>
-  <version_id>eb6a93f9-4678-4ff2-94c7-c1fbae98c287</version_id>
-  <version_modified>20230322T231719Z</version_modified>
+  <version_id>15bc7c2e-e5e2-4c72-8446-f1a5762184be</version_id>
+  <version_modified>20230519T031831Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>UpgradeCosts</class_name>
   <display_name>Upgrade Costs</display_name>
@@ -202,6 +202,18 @@
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
       <checksum>B29FF28D</checksum>
+    </file>
+    <file>
+      <filename>SFD_1story_FB_UA_GRG_MSHP_FuelTanklessWH.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>C330E73B</checksum>
+    </file>
+    <file>
+      <filename>SFD_1story_UB_UA_GRG_ACV_FuelFurnace_PortableHeater_HPWH.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>FD4C5CC3</checksum>
     </file>
   </files>
 </measure>

--- a/test/test_analysis_tools.rb
+++ b/test/test_analysis_tools.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require_relative '../resources/hpxml-measures/HPXMLtoOpenStudio/resources/minitest_helper'
 require 'csv'
 
 class TestTools < MiniTest::Test

--- a/test/test_bsb_analysis.rb
+++ b/test/test_bsb_analysis.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require_relative '../resources/hpxml-measures/HPXMLtoOpenStudio/resources/minitest_helper'
 require_relative '../test/analysis'
 require_relative '../resources/hpxml-measures/HPXMLtoOpenStudio/resources/unit_conversions.rb'
 
@@ -169,8 +169,8 @@ class TesBuildStockBatch < MiniTest::Test
         terms << annual_name if ix == sums_to_ix
       end
 
-      sums_to_val = actual_outputs[sums_to].map { |x| Float(x) }.sum
-      terms_val = terms.collect { |t| actual_outputs[t].map { |x| Float(x) }.sum }.sum
+      sums_to_val = actual_outputs[sums_to].map { |x| !x.nil? ? Float(x) : 0.0 }.sum
+      terms_val = terms.collect { |t| actual_outputs[t].map { |x| !x.nil? ? Float(x) : 0.0 }.sum }.sum
 
       assert_in_epsilon(sums_to_val, terms_val, tol, "Summed value #{terms_val} does not equal #{sums_to} (#{sums_to_val})")
     end
@@ -208,8 +208,8 @@ class TesBuildStockBatch < MiniTest::Test
         terms << annual_name if ix == sums_to_ix
       end
 
-      sums_to_val = actual_outputs[sums_to].map { |x| Float(x) }.sum
-      terms_val = terms.collect { |t| actual_outputs[t].map { |x| Float(x) }.sum }.sum
+      sums_to_val = actual_outputs[sums_to].map { |x| !x.nil? ? Float(x) : 0.0 }.sum
+      terms_val = terms.collect { |t| actual_outputs[t].map { |x| !x.nil? ? Float(x) : 0.0 }.sum }.sum
 
       assert_in_epsilon(sums_to_val, terms_val, tol, "Summed value #{terms_val} does not equal #{sums_to} (#{sums_to_val})")
     end


### PR DESCRIPTION
## Pull Request Description

Install gems so that `test_bsb_analysis.rb` and `test_analysis_tools.rb` can use `minitest_helper`. Also update `test_testing_annual_outputs` and `test_national_annual_outputs` so that nil in results csv files can be handled.

## Checklist

Not all may apply:

- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
