### PR TITLE
Latest OS-HPXML

### DIFF
--- a/measures/ApplyUpgrade/measure.xml
+++ b/measures/ApplyUpgrade/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>apply_upgrade</name>
   <uid>33f1654c-f734-43d1-b35d-9d2856e41b5a</uid>
-  <version_id>e4c3bd24-2fb7-4810-8416-8df29a622c4a</version_id>
-  <version_modified>2023-07-26T22:17:02Z</version_modified>
+  <version_id>4ecb5790-01ae-4240-a5b8-21fb64c40dcf</version_id>
+  <version_modified>2023-08-21T22:19:47Z</version_modified>
   <xml_checksum>9339BE01</xml_checksum>
   <class_name>ApplyUpgrade</class_name>
   <display_name>Apply Upgrade</display_name>
@@ -6330,7 +6330,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>4AA761B5</checksum>
+      <checksum>FD9488A5</checksum>
     </file>
     <file>
       <filename>constants.rb</filename>

--- a/measures/BuildExistingModel/measure.rb
+++ b/measures/BuildExistingModel/measure.rb
@@ -324,10 +324,9 @@ class BuildExistingModel < OpenStudio::Measure::ModelMeasure
       return false
     end
 
-    # Initialize measure keys with hpxml_path arguments
+    # Set BuildResidentialHPXML arguments
     hpxml_path = File.expand_path('../existing.xml')
     measures['BuildResidentialHPXML'] = [{ 'hpxml_path' => hpxml_path }]
-    measures['BuildResidentialScheduleFile'] = [{ 'hpxml_path' => hpxml_path, 'hpxml_output_path' => hpxml_path }]
 
     new_runner.result.stepValues.each do |step_value|
       value = get_value_from_workflow_step_value(step_value)
@@ -336,7 +335,6 @@ class BuildExistingModel < OpenStudio::Measure::ModelMeasure
       measures['BuildResidentialHPXML'][0][step_value.name] = value
     end
 
-    # Set additional properties
     additional_properties = []
     ['ceiling_insulation_r'].each do |arg_name|
       arg_value = measures['ResStockArguments'][0][arg_name]
@@ -344,11 +342,9 @@ class BuildExistingModel < OpenStudio::Measure::ModelMeasure
     end
     measures['BuildResidentialHPXML'][0]['additional_properties'] = additional_properties.join('|') unless additional_properties.empty?
 
-    # Get software program used and version
     measures['BuildResidentialHPXML'][0]['software_info_program_used'] = 'ResStock'
     measures['BuildResidentialHPXML'][0]['software_info_program_version'] = Version::ResStock_Version
 
-    # Get registered values and pass them to BuildResidentialHPXML
     measures['BuildResidentialHPXML'][0]['simulation_control_timestep'] = args[:simulation_control_timestep].get if args[:simulation_control_timestep].is_initialized
     if args[:simulation_control_run_period_begin_month].is_initialized && args[:simulation_control_run_period_begin_day_of_month].is_initialized && args[:simulation_control_run_period_end_month].is_initialized && args[:simulation_control_run_period_end_day_of_month].is_initialized
       begin_month = "#{Date::ABBR_MONTHNAMES[args[:simulation_control_run_period_begin_month].get]}"
@@ -358,6 +354,9 @@ class BuildExistingModel < OpenStudio::Measure::ModelMeasure
       measures['BuildResidentialHPXML'][0]['simulation_control_run_period'] = "#{begin_month} #{begin_day} - #{end_month} #{end_day}"
     end
     measures['BuildResidentialHPXML'][0]['simulation_control_run_period_calendar_year'] = args[:simulation_control_run_period_calendar_year].get if args[:simulation_control_run_period_calendar_year].is_initialized
+
+    measures['BuildResidentialHPXML'][0]['apply_defaults'] = true # for apply_hvac_sizing since ApplyUpgrade sets HVAC capacities
+    measures['BuildResidentialHPXML'][0]['apply_validation'] = true
 
     # Emissions
     if args[:emissions_scenario_names].is_initialized
@@ -611,12 +610,12 @@ class BuildExistingModel < OpenStudio::Measure::ModelMeasure
       measures['BuildResidentialHPXML'][0]['utility_bill_pv_monthly_grid_connection_fees'] = utility_bill_pv_monthly_grid_connection_fees
     end
 
-    # Get registered values and pass them to BuildResidentialScheduleFile
+    # Set BuildResidentialScheduleFile arguments
+    measures['BuildResidentialScheduleFile'] = [{ 'hpxml_path' => hpxml_path, 'hpxml_output_path' => hpxml_path }]
     measures['BuildResidentialScheduleFile'][0]['schedules_random_seed'] = args[:building_id]
     measures['BuildResidentialScheduleFile'][0]['output_csv_path'] = File.expand_path('../schedules.csv')
 
     # Specify measures to run
-    measures['BuildResidentialHPXML'][0]['apply_defaults'] = true # for apply_hvac_sizing
     if run_hescore_workflow
       measures_hash = { 'BuildResidentialHPXML' => measures['BuildResidentialHPXML'] }
     else

--- a/measures/BuildExistingModel/measure.xml
+++ b/measures/BuildExistingModel/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_existing_model</name>
   <uid>dedf59bb-3b88-4f16-8755-2c1ff5519cbf</uid>
-  <version_id>11f19e97-df3d-4923-b8ab-5517e0bdda15</version_id>
-  <version_modified>2023-06-16T15:53:01Z</version_modified>
+  <version_id>19530200-5208-43e5-8657-f0f1df6ea696</version_id>
+  <version_modified>2023-08-21T22:09:39Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildExistingModel</class_name>
   <display_name>Build Existing Model</display_name>
@@ -320,7 +320,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>8AA0977A</checksum>
+      <checksum>BDE2501B</checksum>
     </file>
   </files>
 </measure>

--- a/measures/UpgradeCosts/measure.xml
+++ b/measures/UpgradeCosts/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>upgrade_costs</name>
   <uid>ef51212c-acc4-48d7-9b29-cf2a5c6c4449</uid>
-  <version_id>510b2ab3-8f45-4f46-a902-9d36ad003999</version_id>
-  <version_modified>2023-08-01T18:01:52Z</version_modified>
+  <version_id>c1701f5c-37ad-4148-aff8-70f5e42e8a60</version_id>
+  <version_modified>2023-08-21T22:09:39Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>UpgradeCosts</class_name>
   <display_name>Upgrade Costs</display_name>
@@ -120,6 +120,12 @@
       <checksum>B9183037</checksum>
     </file>
     <file>
+      <filename>SFD_1story_FB_UA_GRG_MSHP_FuelTanklessWH.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>65449877</checksum>
+    </file>
+    <file>
       <filename>SFD_1story_FB_UA_GRG_RoomAC_ElecBoiler_FuelTanklessWH.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
@@ -144,10 +150,22 @@
       <checksum>ABFCA3DB</checksum>
     </file>
     <file>
+      <filename>SFD_1story_UB_UA_GRG_ACV_FuelFurnace_PortableHeater_HPWH.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>076668CA</checksum>
+    </file>
+    <file>
       <filename>SFD_2story_CS_UA_AC2_FuelBoiler_FuelTankWH.osw</filename>
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
       <checksum>B57303D3</checksum>
+    </file>
+    <file>
+      <filename>SFD_2story_CS_UA_AC2_FuelBoiler_FuelTankWH.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>451F9215</checksum>
     </file>
     <file>
       <filename>SFD_2story_CS_UA_GRG_ASHPV_FuelTanklessWH.osw</filename>
@@ -160,6 +178,12 @@
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
       <checksum>986E1AAD</checksum>
+    </file>
+    <file>
+      <filename>SFD_2story_FB_UA_GRG_AC1_ElecBaseboard_FuelTankWH.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>DDDC28CD</checksum>
     </file>
     <file>
       <filename>SFD_2story_FB_UA_GRG_AC1_UnitHeater_FuelTankWH.osw</filename>
@@ -196,6 +220,24 @@
       <filetype>osw</filetype>
       <usage_type>test</usage_type>
       <checksum>B165DD4B</checksum>
+    </file>
+    <file>
+      <filename>in.epw</filename>
+      <filetype>epw</filetype>
+      <usage_type>test</usage_type>
+      <checksum>E23378AA</checksum>
+    </file>
+    <file>
+      <filename>in.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>06875597</checksum>
+    </file>
+    <file>
+      <filename>in.xml</filename>
+      <filetype>xml</filetype>
+      <usage_type>test</usage_type>
+      <checksum>BD7C5A72</checksum>
     </file>
     <file>
       <filename>upgrade_costs_test.rb</filename>

--- a/resources/hpxml-measures/BuildResidentialHPXML/measure.xml
+++ b/resources/hpxml-measures/BuildResidentialHPXML/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>build_residential_hpxml</name>
   <uid>a13a8983-2b01-4930-8af2-42030b6e4233</uid>
-  <version_id>093be6a0-b0ee-4df4-aa77-2a9827f24028</version_id>
-  <version_modified>2023-08-15T14:05:14Z</version_modified>
+  <version_id>454be750-6a0b-4acf-9ab5-53b386e8d9f1</version_id>
+  <version_modified>2023-08-18T19:24:49Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialHPXML</class_name>
   <display_name>HPXML Builder</display_name>
@@ -6741,7 +6741,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>41B0EEFA</checksum>
+      <checksum>EB330C72</checksum>
     </file>
     <file>
       <filename>geometry.rb</filename>
@@ -6753,7 +6753,7 @@
       <filename>build_residential_hpxml_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>4D646B5D</checksum>
+      <checksum>9CC9525F</checksum>
     </file>
   </files>
 </measure>

--- a/resources/hpxml-measures/BuildResidentialHPXML/tests/build_residential_hpxml_test.rb
+++ b/resources/hpxml-measures/BuildResidentialHPXML/tests/build_residential_hpxml_test.rb
@@ -336,6 +336,7 @@ class BuildResidentialHPXMLTest < Minitest::Test
   def _set_measure_argument_values(hpxml_file, args)
     args['hpxml_path'] = File.join(File.dirname(__FILE__), "extra_files/#{hpxml_file}")
     args['apply_defaults'] = true
+    args['apply_validation'] = true
 
     # Base
     if ['base-sfd.xml'].include? hpxml_file

--- a/resources/hpxml-measures/Changelog.md
+++ b/resources/hpxml-measures/Changelog.md
@@ -13,6 +13,7 @@ __New Features__
   - Allow duct area fractions (as an alternative to duct areas in ft^2).
   - Allow duct locations to be provided while defaulting duct areas (i.e., without providing duct area/fraction inputs).
   - Add generic "attic" and "crawlspace" location choices for supply/return ducts, water heater, and battery.
+  - Always validate the HPXML file before applying defaults and only optionally validate the final HPXML file.
 
 __Bugfixes__
 - Fixes lighting multipliers not being applied when kWh/yr inputs are used.

--- a/resources/hpxml-measures/HPXMLtoOpenStudio/measure.xml
+++ b/resources/hpxml-measures/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxm_lto_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>2a50aafc-36c4-4030-831e-1423f8406746</version_id>
-  <version_modified>2023-08-14T17:53:43Z</version_modified>
+  <version_id>5ff9587f-553e-4a7d-9c53-0b4524a0b615</version_id>
+  <version_modified>2023-08-16T14:45:08Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLtoOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -130,7 +130,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>9F4FD400</checksum>
+      <checksum>E8D802F6</checksum>
     </file>
     <file>
       <filename>airflow.rb</filename>
@@ -142,7 +142,7 @@
       <filename>battery.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>14852A93</checksum>
+      <checksum>25CBA96D</checksum>
     </file>
     <file>
       <filename>constants.rb</filename>
@@ -274,7 +274,7 @@
       <filename>hvac.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>344197E3</checksum>
+      <checksum>4B2BF987</checksum>
     </file>
     <file>
       <filename>hvac_sizing.rb</filename>

--- a/resources/hpxml-measures/workflow/tests/hpxml_translator_test.rb
+++ b/resources/hpxml-measures/workflow/tests/hpxml_translator_test.rb
@@ -607,16 +607,16 @@ class HPXMLTest < Minitest::Test
         next if message.include? 'In calculating the design coil UA for Coil:Cooling:Water' # Warning for unused cooling coil for fan coil
       end
       # Boilers
-      if hpxml.heating_systems.select{ |h| h.heating_system_type == HPXML::HVACTypeBoiler }.size > 0
+      if hpxml.heating_systems.select { |h| h.heating_system_type == HPXML::HVACTypeBoiler }.size > 0
         next if message.include? 'Missing temperature setpoint for LeavingSetpointModulated mode' # These warnings are fine, simulation continues with assigning plant loop setpoint to boiler, which is the expected one
       end
       # GSHPs
-      if hpxml.heat_pumps.select{ |hp| hp.heat_pump_type == HPXML::HVACTypeHeatPumpGroundToAir }.size > 0
+      if hpxml.heat_pumps.select { |hp| hp.heat_pump_type == HPXML::HVACTypeHeatPumpGroundToAir }.size > 0
         next if message.include?('CheckSimpleWAHPRatedCurvesOutputs') && message.include?('WaterToAirHeatPump:EquationFit') # FUTURE: Check these
         next if message.include? 'Actual air mass flow rate is smaller than 25% of water-to-air heat pump coil rated air flow rate.' # FUTURE: Remove this when https://github.com/NREL/EnergyPlus/issues/9125 is resolved
       end
       # GSHPs with only heating or cooling
-      if hpxml.heat_pumps.select{ |hp| hp.heat_pump_type == HPXML::HVACTypeHeatPumpGroundToAir && (hp.fraction_heat_load_served == 0 || hp.fraction_cool_load_served == 0) }.size > 0
+      if hpxml.heat_pumps.select { |hp| hp.heat_pump_type == HPXML::HVACTypeHeatPumpGroundToAir && (hp.fraction_heat_load_served == 0 || hp.fraction_cool_load_served == 0) }.size > 0
         next if message.include? 'heating capacity is disproportionate (> 20% different) to total cooling capacity' # safe to ignore
       end
       # Solar thermal systems

--- a/test/test_run_analysis.rb
+++ b/test/test_run_analysis.rb
@@ -118,6 +118,7 @@ class TestRunAnalysis < Minitest::Test
         next if _expected_warning_message(message, 'Home with unconditioned basement/crawlspace foundation type has both foundation wall insulation and floor insulation.')
         next if _expected_warning_message(message, 'Cooling capacity should typically be greater than or equal to 1000 Btu/hr. [context: /HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/CoolingSystem[CoolingSystemType="room air conditioner" or CoolingSystemType="packaged terminal air conditioner"]')
         next if _expected_warning_message(message, 'Cooling capacity should typically be greater than or equal to 1000 Btu/hr. [context: /HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/CoolingSystem[CoolingSystemType="mini-split"]')
+        next if _expected_warning_message(message, 'Heating capacity should typically be greater than or equal to 1000 Btu/hr. [context: /HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/HeatingSystem[HeatingSystemType/Fireplace]')
       end
 
       flunk "Unexpected cli_output.log message found: #{message}"

--- a/test/test_run_analysis.rb
+++ b/test/test_run_analysis.rb
@@ -116,6 +116,7 @@ class TestRunAnalysis < Minitest::Test
         next if _expected_warning_message(message, 'No interior lighting specified, the model will not include interior lighting energy use. [context: /HPXML/Building/BuildingDetails]')
         next if _expected_warning_message(message, 'No exterior lighting specified, the model will not include exterior lighting energy use. [context: /HPXML/Building/BuildingDetails]')
         next if _expected_warning_message(message, 'Home with unconditioned basement/crawlspace foundation type has both foundation wall insulation and floor insulation.')
+        next if _expected_warning_message(message, 'Cooling capacity should typically be greater than or equal to 1000 Btu/hr. [context: /HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/CoolingSystem[CoolingSystemType="room air conditioner" or CoolingSystemType="packaged terminal air conditioner"]')
       end
 
       flunk "Unexpected cli_output.log message found: #{message}"

--- a/test/test_run_analysis.rb
+++ b/test/test_run_analysis.rb
@@ -117,6 +117,7 @@ class TestRunAnalysis < Minitest::Test
         next if _expected_warning_message(message, 'No exterior lighting specified, the model will not include exterior lighting energy use. [context: /HPXML/Building/BuildingDetails]')
         next if _expected_warning_message(message, 'Home with unconditioned basement/crawlspace foundation type has both foundation wall insulation and floor insulation.')
         next if _expected_warning_message(message, 'Cooling capacity should typically be greater than or equal to 1000 Btu/hr. [context: /HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/CoolingSystem[CoolingSystemType="room air conditioner" or CoolingSystemType="packaged terminal air conditioner"]')
+        next if _expected_warning_message(message, 'Cooling capacity should typically be greater than or equal to 1000 Btu/hr. [context: /HPXML/Building/BuildingDetails/Systems/HVAC/HVACPlant/CoolingSystem[CoolingSystemType="mini-split"]')
       end
 
       flunk "Unexpected cli_output.log message found: #{message}"


### PR DESCRIPTION
## Pull Request Description

Pulls in:
- [x] https://github.com/NREL/OpenStudio-HPXML/pull/1467
- [ ] https://github.com/NREL/OpenStudio-HPXML/pull/1466
- [ ] https://github.com/NREL/OpenStudio-HPXML/pull/1469

Checked means that something in resstock was changed or updated as a result of pulling in.

Questions:
* Should we re-think when/where validation on the HPXML file is performed? Currently we skip validation from HPXMLtoOpenStudio. Instead, we validate both before and after applying defaults from BuildExistingModel and ApplyUpgrade. (We apply defaults from ApplyUpgrade so that home.xml looks similar to the home.xml produced when there are no upgrades.) Validation therefore happens 2 times for a home with no upgrade, and 4 times for a home with an upgrade. Should we switch back to having HPXMLtoOpenStudio do the validation? Then we would only be validating 2 times (when no upgrade) or 3 times (when upgrade).

## Checklist

Not all may apply:

- [x] Tests (and test files) have been updated
- [ ] ~Documentation has been updated~
  - [ ] ~If related to resstock-estimation, checklist includes [data dictionary](https://github.com/NREL/resstock/tree/develop/resources/data/dictionary), [source report](https://github.com/NREL/resstock/tree/develop/project_national/resources/source_report.csv), [options_lookup](https://github.com/NREL/resstock/blob/develop/resources/options_lookup.tsv).~
  - [ ] ~If changes to project_testing tsvs, checklist includes [yml_precomputed](https://github.com/NREL/resstock/tree/develop/test/tests_yml_files/yml_precomputed), [yml_precomputed_outdated](https://github.com/NREL/resstock/tree/develop/test/tests_yml_files/yml_precomputed_outdated), [yml_precomputed_weight](https://github.com/NREL/resstock/tree/develop/test/tests_yml_files/yml_precomputed_weight)~
- [ ] ~Changelog has been updated~
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI (checked comparison artifacts)
