### PR TITLE
Less stringent run_analysis.rb dependencies

### DIFF
--- a/resources/buildstock.rb
+++ b/resources/buildstock.rb
@@ -1,16 +1,8 @@
 # frozen_string_literal: true
 
-require 'openstudio'
-if File.exist? File.absolute_path(File.join(File.dirname(__FILE__), '../lib/resources/hpxml-measures/HPXMLtoOpenStudio/resources')) # Hack to run ResStock on AWS
-  resources_path = File.absolute_path(File.join(File.dirname(__FILE__), '../lib/resources/hpxml-measures/HPXMLtoOpenStudio/resources'))
-elsif File.exist? File.absolute_path(File.join(File.dirname(__FILE__), 'hpxml-measures/HPXMLtoOpenStudio/resources')) # Hack to run ResStock unit tests locally
-  resources_path = File.absolute_path(File.join(File.dirname(__FILE__), 'hpxml-measures/HPXMLtoOpenStudio/resources'))
-elsif File.exist? File.join(OpenStudio::BCLMeasure::userMeasuresDir.to_s, 'HPXMLtoOpenStudio/resources') # Hack to run measures in the OS App since applied measures are copied off into a temporary directory
-  resources_path = File.join(OpenStudio::BCLMeasure::userMeasuresDir.to_s, 'HPXMLtoOpenStudio/resources')
-end
-require File.join(resources_path, 'meta_measure')
-
 require 'csv'
+
+require_relative '../resources/hpxml-measures/HPXMLtoOpenStudio/resources/meta_measure'
 
 class TsvFile
   def initialize(full_path, runner)
@@ -452,6 +444,7 @@ def get_data_for_sample(buildstock_csv_path, building_id, runner)
 end
 
 class RunOSWs
+  require 'openstudio'
   require 'csv'
   require 'json'
 

--- a/workflow/run_analysis.rb
+++ b/workflow/run_analysis.rb
@@ -3,6 +3,9 @@
 require 'parallel'
 require 'json'
 require 'yaml'
+require 'optparse'
+require 'pathname'
+require 'time'
 
 require_relative '../resources/buildstock'
 require_relative '../resources/run_sampling_lib'


### PR DESCRIPTION
## Pull Request Description

Avoid loading `openstudio` at the top of `buildstock.rb`. For example, we don't need it when only running sampling using `run_analysis.rb`.

## Checklist

Not all may apply:

- [ ] ~Tests (and test files) have been updated~
- [ ] ~Documentation has been updated~
  - [ ] ~If related to resstock-estimation, checklist includes [data dictionary](https://github.com/NREL/resstock/tree/develop/resources/data/dictionary), [source report](https://github.com/NREL/resstock/tree/develop/project_national/resources/source_report.csv), [options_lookup](https://github.com/NREL/resstock/blob/develop/resources/options_lookup.tsv).~
  - [ ] ~If changes to project_testing tsvs, checklist includes [yml_precomputed](https://github.com/NREL/resstock/tree/develop/test/tests_yml_files/yml_precomputed), [yml_precomputed_outdated](https://github.com/NREL/resstock/tree/develop/test/tests_yml_files/yml_precomputed_outdated), [yml_precomputed_weight](https://github.com/NREL/resstock/tree/develop/test/tests_yml_files/yml_precomputed_weight)~
- [ ] ~Changelog has been updated~
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI (checked comparison artifacts)
