### PR TITLE
Fix docs again, Gem::Version on bsb version strings

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,11 @@ version: 2
 sphinx:
   configuration: docs/read_the_docs/source/conf.py
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
 python:
-  version: "3.8"
   install:
     - requirements: docs/read_the_docs/requirements.txt

--- a/resources/buildstock.rb
+++ b/resources/buildstock.rb
@@ -555,7 +555,7 @@ class Version
   def self.check_buildstockbatch_version
     if ENV.keys.include?('BUILDSTOCKBATCH_VERSION') # buildstockbatch is installed
       bsb_version = ENV['BUILDSTOCKBATCH_VERSION']
-      if bsb_version < BuildStockBatch_Version
+      if Gem::Version.new(bsb_version) < Gem::Version.new(BuildStockBatch_Version)
         fail "BuildStockBatch version #{BuildStockBatch_Version} or above is required. Found version: #{bsb_version}"
       end
     end


### PR DESCRIPTION
## Pull Request Description

[description here]

## Checklist

Not all may apply:

- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
  - [ ] If related to resstock-estimation, checklist includes [data dictionary](https://github.com/NREL/resstock/tree/develop/resources/data/dictionary), [source report](https://github.com/NREL/resstock/tree/develop/project_national/resources/source_report.csv), [options saturation](https://github.com/NREL/resstock/tree/develop/project_national/resources/options_saturations.csv), [options_lookup](https://github.com/NREL/resstock/blob/develop/resources/options_lookup.tsv).
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
