### PR TITLE
ServerDirectoryCleanup: fix retaining `eplustbl.htm` when debug is enabled

### DIFF
--- a/measures/ServerDirectoryCleanup/measure.rb
+++ b/measures/ServerDirectoryCleanup/measure.rb
@@ -161,7 +161,7 @@ class ServerDirectoryCleanup < OpenStudio::Measure::ReportingMeasure
     debug = runner.getBoolArgumentValue('debug', user_arguments)
 
     if debug
-      in_osm = in_idf = pre_process_idf = eplusout_audit = eplusout_bnd = eplusout_eio = eplusout_end = eplusout_err = eplusout_eso = eplusout_mdd = eplusout_mtd = eplusout_rdd = eplusout_shd = eplusout_msgpack = stdout_energyplus = stdout_expandobject = schedules_csv = true
+      in_osm = in_idf = pre_process_idf = eplusout_audit = eplusout_bnd = eplusout_eio = eplusout_end = eplusout_err = eplusout_eso = eplusout_mdd = eplusout_mtd = eplusout_rdd = eplusout_shd = eplusout_msgpack = eplustbl_htm = stdout_energyplus = stdout_expandobject = schedules_csv = true
     end
 
     Dir.glob('./../in.osm').each do |f|

--- a/measures/ServerDirectoryCleanup/measure.xml
+++ b/measures/ServerDirectoryCleanup/measure.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <measure>
-  <schema_version>3.0</schema_version>
+  <schema_version>3.1</schema_version>
   <name>server_directory_cleanup</name>
   <uid>ec7d04ad-0b7b-495b-825a-e1b6d28d1d3f</uid>
-  <version_id>d7831eec-3624-4678-8a03-7ae55c5908d7</version_id>
-  <version_modified>20230406T225316Z</version_modified>
+  <version_id>797ac72a-9e4b-49c4-9529-7de9d7652aad</version_id>
+  <version_modified>2023-11-02T15:23:58Z</version_modified>
   <xml_checksum>5F1EDF75</xml_checksum>
   <class_name>ServerDirectoryCleanup</class_name>
   <display_name>Server Directory Cleanup</display_name>
@@ -382,7 +382,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>6D96C46D</checksum>
+      <checksum>3B2978B0</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
## Pull Request Description

[description here]

## Checklist

Not all may apply:

- [ ] ~Tests (and test files) have been updated~
- [ ] ~Documentation has been updated~
  - [ ] ~If related to resstock-estimation, checklist includes [data dictionary](https://github.com/NREL/resstock/tree/develop/resources/data/dictionary), [source report](https://github.com/NREL/resstock/tree/develop/project_national/resources/source_report.csv), [options saturation](https://github.com/NREL/resstock/tree/develop/project_national/resources/options_saturations.csv), [options_lookup](https://github.com/NREL/resstock/blob/develop/resources/options_lookup.tsv).~
- [ ] ~Changelog has been updated~
- [x] `openstudio tasks.rb update_measures` has been run~
- [x] No unexpected regression test changes on CI (checked comparison artifacts)~
