### PR TITLE
Add all software versions to `run_analysis.rb`

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -15,7 +15,7 @@ jobs:
     name: Add pull request or issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.3.0
+      - uses: actions/add-to-project@v1.0.0
         with:
           project-url: https://github.com/orgs/NREL/projects/38
           github-token: ${{ secrets.GHB_TOKEN }}

--- a/resources/hpxml-measures/workflow/run_simulation.rb
+++ b/resources/hpxml-measures/workflow/run_simulation.rb
@@ -193,6 +193,7 @@ end.parse!
 
 if options[:version]
   puts "OpenStudio-HPXML v#{Version::OS_HPXML_Version}"
+  puts "HPXML v#{Version::HPXML_Version}"
   puts "OpenStudio v#{OpenStudio.openStudioLongVersion}"
   puts "EnergyPlus v#{OpenStudio.energyPlusVersion}.#{OpenStudio.energyPlusBuildSHA}"
 else

--- a/test/test_run_analysis.rb
+++ b/test/test_run_analysis.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../resources/hpxml-measures/HPXMLtoOpenStudio/resources/minitest_helper'
+require_relative '../resources/hpxml-measures/HPXMLtoOpenStudio/resources/version'
 require_relative '../resources/buildstock'
 require_relative '../test/analysis'
 require 'openstudio'
@@ -142,6 +143,9 @@ class TestRunAnalysis < Minitest::Test
     cli_output = `#{@command}`
 
     assert_includes(cli_output, "ResStock v#{Version::ResStock_Version}")
+    assert_includes(cli_output, "OpenStudio-HPXML v#{Version::OS_HPXML_Version}")
+    assert_includes(cli_output, "OpenStudio v#{OpenStudio.openStudioLongVersion}")
+    assert_includes(cli_output, "EnergyPlus v#{OpenStudio.energyPlusVersion}.#{OpenStudio.energyPlusBuildSHA}")
   end
 
   def test_errors_wrong_path

--- a/test/test_run_analysis.rb
+++ b/test/test_run_analysis.rb
@@ -144,6 +144,7 @@ class TestRunAnalysis < Minitest::Test
 
     assert_includes(cli_output, "ResStock v#{Version::ResStock_Version}")
     assert_includes(cli_output, "OpenStudio-HPXML v#{Version::OS_HPXML_Version}")
+    assert_includes(cli_output, "HPXML v#{Version::HPXML_Version}")
     assert_includes(cli_output, "OpenStudio v#{OpenStudio.openStudioLongVersion}")
     assert_includes(cli_output, "EnergyPlus v#{OpenStudio.energyPlusVersion}.#{OpenStudio.energyPlusBuildSHA}")
   end

--- a/workflow/run_analysis.rb
+++ b/workflow/run_analysis.rb
@@ -667,7 +667,7 @@ end.parse!
 if options[:version]
   puts "ResStock v#{Version::ResStock_Version}"
   cli_path = OpenStudio.getOpenStudioCLI
-  command = "\"#{cli_path}\" resources/hpxml-measures/workflow/run_simulation.rb -v"
+  command = "\"#{cli_path}\" #{File.dirname(__FILE__)}/../resources/hpxml-measures/workflow/run_simulation.rb -v"
   system(command)
 else
   if not options[:yml]

--- a/workflow/run_analysis.rb
+++ b/workflow/run_analysis.rb
@@ -666,6 +666,9 @@ end.parse!
 
 if options[:version]
   puts "ResStock v#{Version::ResStock_Version}"
+  cli_path = OpenStudio.getOpenStudioCLI
+  command = "\"#{cli_path}\" resources/hpxml-measures/workflow/run_simulation.rb -v"
+  system(command)
 else
   if not options[:yml]
     puts "Error: YML argument is required. Call #{File.basename(__FILE__)} -h for usage."


### PR DESCRIPTION
## Pull Request Description

[description here]

## Checklist

Not all may apply:

- [x] Tests (and test files) have been updated
- [ ] ~Documentation has been updated~
  - [ ] ~If related to resstock-estimation, checklist includes [data dictionary](https://github.com/NREL/resstock/tree/develop/resources/data/dictionary), [source report](https://github.com/NREL/resstock/tree/develop/project_national/resources/source_report.csv), [options saturation](https://github.com/NREL/resstock/tree/develop/project_national/resources/options_saturations.csv), [options_lookup](https://github.com/NREL/resstock/blob/develop/resources/options_lookup.tsv).~
- [ ] ~Changelog has been updated~
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI (checked comparison artifacts)
