### PR TITLE
Add changlog package to requirements.txt

### DIFF
--- a/docs/read_the_docs/requirements.txt
+++ b/docs/read_the_docs/requirements.txt
@@ -3,3 +3,4 @@ sphinx_rtd_theme>=1.1.0
 sphinx-autobuild
 sphinxcontrib-programoutput
 sphinx_paramlinks
+changelog


### PR DESCRIPTION
## Pull Request Description

The changlog on read-the-docs stopped rendering. The text exists in the changelog *.rst files, but read-the-docs was not rendering the changelog. I built the docs locally and this error showed up, but did not cause the docs build to fail.
```
Extension error:
Could not import extension changelog (exception: No module named 'changelog')
Sphinx exited with exit code: 2
```
Looking at BuildStock-Batch, I saw that "changelog" was in the [setup.py](https://github.com/NREL/buildstockbatch/blob/1509ad2ad041400f38b268816976d94499a82783/setup.py#L72). I did not see the package "changelog" in the [requirements.txt](https://github.com/NREL/resstock/blob/develop/docs/read_the_docs/requirements.txt). 

When I added the "changelog" package to the requirements.txt, the docs rendered locally for me on a mac.
## Checklist

Not all may apply:

- [ ] Tests (and test files) have been updated
- [x] Documentation has been updated
  - [ ] If related to resstock-estimation, checklist includes [data dictionary](https://github.com/NREL/resstock/tree/develop/resources/data/dictionary), [source report](https://github.com/NREL/resstock/tree/develop/project_national/resources/source_report.csv), [options saturation](https://github.com/NREL/resstock/tree/develop/project_national/resources/options_saturations.csv), [options_lookup](https://github.com/NREL/resstock/blob/develop/resources/options_lookup.tsv).
- [ ] Add to the [changelog_dev.rst file](https://github.com/NREL/resstock/tree/develop/docs/read_the_docs/source/changelog/changelog_dev.rst)
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
