### PR TITLE
Map mobile homes to HPXML's "manufactured home"

### DIFF
--- a/docs/read_the_docs/source/workflow_inputs/characteristics.rst
+++ b/docs/read_the_docs/source/workflow_inputs/characteristics.rst
@@ -36375,7 +36375,7 @@ From ``project_national`` the list of options, option stock sturation, and optio
 
    * - Mobile Home
      - 6.2%
-     - single-family detached
+     - manufactured home
      - 1.8
      - 8
    * - Multi-Family with 2 - 4 Units

--- a/measures/ResStockArguments/measure.rb
+++ b/measures/ResStockArguments/measure.rb
@@ -408,33 +408,43 @@ class ResStockArguments < OpenStudio::Measure::ModelMeasure
 
     # Conditioned floor area
     if args[:geometry_unit_cfa] == Constants.Auto
+      # FIXME: Need to disaggregate detached and mobile home
       cfas = { ['0-499', HPXML::ResidentialTypeSFD] => 298, # AHS 2021, 1 detached and mobile home weighted average
-               ['0-499', HPXML::ResidentialTypeSFA] => 273, # AHS 2021, 1 detached and mobile home weighted average
+               ['0-499', HPXML::ResidentialTypeSFA] => 273, # AHS 2021, 1 attached
                ['0-499', HPXML::ResidentialTypeApartment] => 322, # AHS 2021, multi-family weighted average
+               ['0-499', HPXML::ResidentialTypeManufactured] => 298, # AHS 2021, 1 detached and mobile home weighted average
                ['500-749', HPXML::ResidentialTypeSFD] => 634, # AHS 2021, 1 detached and mobile home weighted average
                ['500-749', HPXML::ResidentialTypeSFA] => 625, # AHS 2021, 1 attached
                ['500-749', HPXML::ResidentialTypeApartment] => 623, # AHS 2021, multi-family weighted average
+               ['500-749', HPXML::ResidentialTypeManufactured] => 634, # AHS 2021, 1 detached and mobile home weighted average
                ['750-999', HPXML::ResidentialTypeSFD] => 881, # AHS 2021, 1 detached and mobile home weighted average
                ['750-999', HPXML::ResidentialTypeSFA] => 872, # AHS 2021, 1 attached
                ['750-999', HPXML::ResidentialTypeApartment] => 854, # AHS 2021, multi-family weighted average
+               ['750-999', HPXML::ResidentialTypeManufactured] => 881, # AHS 2021, 1 detached and mobile home weighted average
                ['1000-1499', HPXML::ResidentialTypeSFD] => 1228, # AHS 2021, 1 detached and mobile home weighted average
                ['1000-1499', HPXML::ResidentialTypeSFA] => 1207, # AHS 2021, 1 attached
                ['1000-1499', HPXML::ResidentialTypeApartment] => 1138, # AHS 2021, multi-family weighted average
+               ['1000-1499', HPXML::ResidentialTypeManufactured] => 1228, # AHS 2021, 1 detached and mobile home weighted average
                ['1500-1999', HPXML::ResidentialTypeSFD] => 1698, # AHS 2021, 1 detached and mobile home weighted average
                ['1500-1999', HPXML::ResidentialTypeSFA] => 1678, # AHS 2021, 1 attached
                ['1500-1999', HPXML::ResidentialTypeApartment] => 1682, # AHS 2021, multi-family weighted average
+               ['1500-1999', HPXML::ResidentialTypeManufactured] => 1698, # AHS 2021, 1 detached and mobile home weighted average
                ['2000-2499', HPXML::ResidentialTypeSFD] => 2179, # AHS 2021, 1 detached and mobile home weighted average
                ['2000-2499', HPXML::ResidentialTypeSFA] => 2152, # AHS 2021, 1 attached
                ['2000-2499', HPXML::ResidentialTypeApartment] => 2115, # AHS 2021, multi-family weighted average
+               ['2000-2499', HPXML::ResidentialTypeManufactured] => 2179, # AHS 2021, 1 detached and mobile home weighted average
                ['2500-2999', HPXML::ResidentialTypeSFD] => 2678, # AHS 2021, 1 detached and mobile home weighted average
                ['2500-2999', HPXML::ResidentialTypeSFA] => 2663, # AHS 2021, 1 attached
                ['2500-2999', HPXML::ResidentialTypeApartment] => 2648, # AHS 2021, multi-family weighted average
+               ['2500-2999', HPXML::ResidentialTypeManufactured] => 2678, # AHS 2021, 1 detached and mobile home weighted average
                ['3000-3999', HPXML::ResidentialTypeSFD] => 3310, # AHS 2021, 1 detached and mobile home weighted average
                ['3000-3999', HPXML::ResidentialTypeSFA] => 3228, # AHS 2021, 1 attached
                ['3000-3999', HPXML::ResidentialTypeApartment] => 3171, # AHS 2021, multi-family weighted average
+               ['3000-3999', HPXML::ResidentialTypeManufactured] => 3310, # AHS 2021, 1 detached and mobile home weighted average
                ['4000+', HPXML::ResidentialTypeSFD] => 5587, # AHS 2021, 1 detached and mobile home weighted average
                ['4000+', HPXML::ResidentialTypeSFA] => 7414, # AHS 2019, 1 attached
-               ['4000+', HPXML::ResidentialTypeApartment] => 6348 } # AHS 2021, 4,000 or more all unit average
+               ['4000+', HPXML::ResidentialTypeApartment] => 6348, # AHS 2021, 4,000 or more all unit average
+               ['4000+', HPXML::ResidentialTypeManufactured] => 5587 } # AHS 2021, 1 detached and mobile home weighted average
       cfa = cfas[[args[:geometry_unit_cfa_bin], args[:geometry_unit_type]]]
       if cfa.nil?
         runner.registerError("ResStockArguments: Could not look up conditioned floor area for '#{args[:geometry_unit_cfa_bin]}' and '#{args[:geometry_unit_type]}'.")
@@ -465,7 +475,8 @@ class ResStockArguments < OpenStudio::Measure::ModelMeasure
 
     # Other
     if args[:misc_plug_loads_other_annual_kwh].to_s == Constants.Auto
-      if [HPXML::ResidentialTypeSFD].include?(args[:geometry_unit_type])
+      # FIXME: Need to disaggregate detached and mobile home
+      if [HPXML::ResidentialTypeSFD, HPXML::ResidentialTypeManufactured].include?(args[:geometry_unit_type])
         args[:misc_plug_loads_other_annual_kwh] = 863.26 + 219.26 * args[:geometry_unit_num_occupants] + 0.33 * args[:geometry_unit_cfa] # RECS 2020
       elsif [HPXML::ResidentialTypeSFA].include?(args[:geometry_unit_type])
         args[:misc_plug_loads_other_annual_kwh] = 654.92 + 206.52 * args[:geometry_unit_num_occupants] + 0.21 * args[:geometry_unit_cfa] # RECS 2020

--- a/measures/ResStockArguments/measure.rb
+++ b/measures/ResStockArguments/measure.rb
@@ -408,7 +408,7 @@ class ResStockArguments < OpenStudio::Measure::ModelMeasure
 
     # Conditioned floor area
     if args[:geometry_unit_cfa] == Constants.Auto
-      # FIXME: Need to disaggregate detached and mobile home
+      # TODO: Disaggregate detached and mobile home
       cfas = { ['0-499', HPXML::ResidentialTypeSFD] => 298, # AHS 2021, 1 detached and mobile home weighted average
                ['0-499', HPXML::ResidentialTypeSFA] => 273, # AHS 2021, 1 attached
                ['0-499', HPXML::ResidentialTypeApartment] => 322, # AHS 2021, multi-family weighted average
@@ -475,7 +475,7 @@ class ResStockArguments < OpenStudio::Measure::ModelMeasure
 
     # Other
     if args[:misc_plug_loads_other_annual_kwh].to_s == Constants.Auto
-      # FIXME: Need to disaggregate detached and mobile home
+      # TODO: Disaggregate detached and mobile home
       if [HPXML::ResidentialTypeSFD, HPXML::ResidentialTypeManufactured].include?(args[:geometry_unit_type])
         args[:misc_plug_loads_other_annual_kwh] = 863.26 + 219.26 * args[:geometry_unit_num_occupants] + 0.33 * args[:geometry_unit_cfa] # RECS 2020
       elsif [HPXML::ResidentialTypeSFA].include?(args[:geometry_unit_type])

--- a/measures/ResStockArguments/measure.xml
+++ b/measures/ResStockArguments/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>res_stock_arguments</name>
   <uid>c984bb9e-4ac4-4930-a399-9d23f8f6936a</uid>
-  <version_id>1c72228d-9e8d-4b2b-9f0a-7808a8425f2c</version_id>
-  <version_modified>2024-07-11T22:05:34Z</version_modified>
+  <version_id>f7dbede4-8a9f-4ff1-a102-0e7251ecb454</version_id>
+  <version_modified>2024-07-12T14:41:41Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>ResStockArguments</class_name>
   <display_name>ResStock Arguments</display_name>
@@ -7497,7 +7497,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>F1A6AC1F</checksum>
+      <checksum>A1951B73</checksum>
     </file>
     <file>
       <filename>constants.rb</filename>

--- a/measures/ResStockArguments/measure.xml
+++ b/measures/ResStockArguments/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>res_stock_arguments</name>
   <uid>c984bb9e-4ac4-4930-a399-9d23f8f6936a</uid>
-  <version_id>d38cd429-d4e6-495c-a421-8f06b2391798</version_id>
-  <version_modified>2024-06-21T02:11:37Z</version_modified>
+  <version_id>1c72228d-9e8d-4b2b-9f0a-7808a8425f2c</version_id>
+  <version_modified>2024-07-11T22:05:34Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>ResStockArguments</class_name>
   <display_name>ResStock Arguments</display_name>
@@ -7497,7 +7497,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>96F4DFC0</checksum>
+      <checksum>F1A6AC1F</checksum>
     </file>
     <file>
       <filename>constants.rb</filename>

--- a/resources/options_lookup.tsv
+++ b/resources/options_lookup.tsv
@@ -9361,7 +9361,7 @@ Geometry Building Type Height	Mobile Home
 Geometry Building Type Height	Multifamily with 2-4 Units
 Geometry Building Type Height	Single-Family Attached
 Geometry Building Type Height	Single-Family Detached
-Geometry Building Type RECS	Mobile Home	ResStockArguments	geometry_unit_type=single-family detached	geometry_average_ceiling_height=8	geometry_unit_aspect_ratio=1.8
+Geometry Building Type RECS	Mobile Home	ResStockArguments	geometry_unit_type=manufactured home	geometry_average_ceiling_height=8	geometry_unit_aspect_ratio=1.8
 Geometry Building Type RECS	Multi-Family with 2 - 4 Units	ResStockArguments	geometry_unit_type=apartment unit	geometry_average_ceiling_height=8	geometry_unit_aspect_ratio=0.5556
 Geometry Building Type RECS	Multi-Family with 5+ Units	ResStockArguments	geometry_unit_type=apartment unit	geometry_average_ceiling_height=8	geometry_unit_aspect_ratio=0.5556
 Geometry Building Type RECS	Single-Family Attached	ResStockArguments	geometry_unit_type=single-family attached	geometry_average_ceiling_height=8	geometry_unit_aspect_ratio=0.5556


### PR DESCRIPTION
## Pull Request Description

Maps mobile homes to HPXML using "manufactured home" instead of "single-family detached". Partially addresses #1098.

## Checklist

Not all may apply:

- [ ] ~Tests (and test files) have been updated~
- [x] Documentation has been updated
  - [ ] ~If related to resstock-estimation, checklist includes [data dictionary](https://github.com/NREL/resstock/tree/develop/resources/data/dictionary), [source report](https://github.com/NREL/resstock/tree/develop/project_national/resources/source_report.csv), [options saturation](https://github.com/NREL/resstock/tree/develop/project_national/resources/options_saturations.csv), [options_lookup](https://github.com/NREL/resstock/blob/develop/resources/options_lookup.tsv).~
- [ ] ~Add to the [changelog_dev.rst file](https://github.com/NREL/resstock/tree/develop/docs/read_the_docs/source/changelog/changelog_dev.rst)~
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI (checked comparison artifacts)
