### PR TITLE
Speed up TSVFile class

### DIFF
--- a/resources/buildstock.rb
+++ b/resources/buildstock.rb
@@ -72,8 +72,8 @@ class TsvFile
       end
 
       if not rows_keys_s[row_key_values].nil?
-        if key_s.size > 0
-          register_error("Multiple rows found in #{@filename} with dependencies: #{key_s}.", @runner)
+        if not row_key_values.empty?
+          register_error("Multiple rows found in #{@filename} with dependencies: #{hash_to_string(row_key_values)}.", @runner)
         else
           register_error("Multiple rows found in #{@filename}.", @runner)
         end
@@ -96,7 +96,7 @@ class TsvFile
 
     rownum = @rows_keys_s[dependency_values]
     if rownum.nil?
-      if key_s.size > 0
+      if not dependency_values.empty?
         register_error("Could not determine appropriate option in #{@filename} for sample value #{sample_value} with dependencies: #{hash_to_string(dependency_values)}.", @runner)
       else
         register_error("Could not determine appropriate option in #{@filename} for sample value #{sample_value}.", @runner)

--- a/resources/buildstock.rb
+++ b/resources/buildstock.rb
@@ -19,21 +19,10 @@ class TsvFile
     option_key = 'Option='
     dep_key = 'Dependency='
 
-    full_header = nil
-    rows = []
-    CSV.foreach(@full_path, col_sep: "\t") do |row|
-      next if row[0].start_with? "\#"
-
-      row.delete_if { |x| x.nil? || (x.size == 0) } # purge trailing empty fields
-
-      # Store one header line
-      if full_header.nil?
-        full_header = row
-        next
-      end
-
-      rows << row
-    end
+    rows = File.readlines(@full_path).map { |row| row.split("\t") } # don't use CSV class for faster processing of large files
+    full_header = rows.shift
+    rows.delete_if { |row| row[0].start_with? "\#" }
+    rows.map { |row| row.delete_if { |x| x.to_s.empty? } } # purge trailing empty fields
 
     if full_header.nil?
       register_error("Could not find header row in #{@filename}.", @runner)
@@ -65,11 +54,9 @@ class TsvFile
     dependency_cols.each do |dependency, col|
       dependency_options[dependency] = []
       rows.each do |row|
-        next if row[0].start_with? "\#"
-        next if dependency_options[dependency].include? row[col]
-
         dependency_options[dependency] << row[col]
       end
+      dependency_options[dependency].uniq!
     end
 
     return rows, option_cols, dependency_cols, dependency_options, full_header, header
@@ -79,16 +66,12 @@ class TsvFile
     # Caches data for faster tsv lookups
     rows_keys_s = {}
     @rows.each_with_index do |row, rownum|
-      next if row[0].start_with? "\#"
-
       row_key_values = {}
-      @dependency_cols.keys.each do |dep|
-        row_key_values[dep] = row[@dependency_cols[dep]]
+      @dependency_cols.each do |dep, col|
+        row_key_values[dep] = row[col]
       end
-      key_s = hash_to_string(row_key_values)
-      key_s_downcase = key_s.downcase
 
-      if not rows_keys_s[key_s_downcase].nil?
+      if not rows_keys_s[row_key_values].nil?
         if key_s.size > 0
           register_error("Multiple rows found in #{@filename} with dependencies: #{key_s}.", @runner)
         else
@@ -96,7 +79,7 @@ class TsvFile
         end
       end
 
-      rows_keys_s[key_s_downcase] = rownum
+      rows_keys_s[row_key_values] = rownum
     end
     return rows_keys_s
   end
@@ -111,13 +94,10 @@ class TsvFile
       dependency_values = {}
     end
 
-    key_s = hash_to_string(dependency_values)
-    key_s_downcase = key_s.downcase
-
-    rownum = @rows_keys_s[key_s_downcase]
+    rownum = @rows_keys_s[dependency_values]
     if rownum.nil?
       if key_s.size > 0
-        register_error("Could not determine appropriate option in #{@filename} for sample value #{sample_value} with dependencies: #{key_s}.", @runner)
+        register_error("Could not determine appropriate option in #{@filename} for sample value #{sample_value} with dependencies: #{hash_to_string(dependency_values)}.", @runner)
       else
         register_error("Could not determine appropriate option in #{@filename} for sample value #{sample_value}.", @runner)
       end

--- a/resources/buildstock.rb
+++ b/resources/buildstock.rb
@@ -22,7 +22,7 @@ class TsvFile
     rows = File.readlines(@full_path).map { |row| row.split("\t") } # don't use CSV class for faster processing of large files
     full_header = rows.shift
     rows.delete_if { |row| row[0].start_with? "\#" }
-    rows.map { |row| row.delete_if { |x| x.to_s.empty? } } # purge trailing empty fields
+    rows.map! { |row| row.delete_if { |x| x.to_s.empty? } } # purge trailing empty fields
 
     if full_header.nil?
       register_error("Could not find header row in #{@filename}.", @runner)

--- a/resources/hpxml-measures/HPXMLtoOpenStudio/resources/meta_measure.rb
+++ b/resources/hpxml-measures/HPXMLtoOpenStudio/resources/meta_measure.rb
@@ -407,14 +407,11 @@ def run_measure(model, measure, argument_map, runner)
 end
 
 def hash_to_string(hash, delim = '=', separator = ',')
-  hash_s = ''
+  vals = []
   hash.each do |k, v|
-    hash_s += "#{k}#{delim}#{v}#{separator}"
+    vals << "#{k}#{delim}#{v}"
   end
-  if hash_s.size > 0
-    hash_s = hash_s.chomp(separator.to_s)
-  end
-  return hash_s
+  return vals.join(separator.to_s)
 end
 
 def register_error(msg, runner = nil)

--- a/resources/run_sampling_lib.rb
+++ b/resources/run_sampling_lib.rb
@@ -153,9 +153,7 @@ class RunSampling
       return tsvfile.rows[0]
     end
 
-    key_s = hash_to_string(dep_hash)
-    key_s_downcase = key_s.downcase
-    rownum = tsvfile.rows_keys_s[key_s_downcase]
+    rownum = tsvfile.rows_keys_s[dep_hash]
 
     if rownum.nil?
       register_error("Could not find row in #{tsvfile.filename} with dependency values: #{dep_hash}.", nil)


### PR DESCRIPTION
## Pull Request Description

Speeds up the TSVFile class. When running smaller sample sizes, the initial reading of the large TSV files is the bottleneck. For e.g. 250 samples, this roughly cuts the time in half.

## Checklist

Not all may apply:

- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
  - [ ] If related to resstock-estimation, checklist includes [data dictionary](https://github.com/NREL/resstock/tree/develop/resources/data/dictionary), [source report](https://github.com/NREL/resstock/tree/develop/project_national/resources/source_report.csv), [options saturation](https://github.com/NREL/resstock/tree/develop/project_national/resources/options_saturations.csv), [options_lookup](https://github.com/NREL/resstock/blob/develop/resources/options_lookup.tsv).
- [ ] Add to the [changelog_dev.rst file](https://github.com/NREL/resstock/tree/develop/docs/read_the_docs/source/changelog/changelog_dev.rst)
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
