### PR TITLE
ServerDirectoryCleanup: catch *schedules.csv, refactor

### DIFF
--- a/docs/read_the_docs/source/basic_tutorial/architecture.rst
+++ b/docs/read_the_docs/source/basic_tutorial/architecture.rst
@@ -202,3 +202,7 @@ They process and report simulation output.
   .. include:: ../../../../measures/ServerDirectoryCleanup/measure.xml
      :start-after: <description>
      :end-before: <
+
+  .. include:: ../../../../measures/ServerDirectoryCleanup/measure.xml
+     :start-after: <modeler_description>
+     :end-before: <

--- a/docs/read_the_docs/source/changelog/changelog_dev.rst
+++ b/docs/read_the_docs/source/changelog/changelog_dev.rst
@@ -13,11 +13,11 @@ Development Changelog
         **Date**: 2024-07-22
 
         Title:
-        ServerDirectoryCleanup: catch *schedules.csv, refactor
+        ServerDirectoryCleanup: catch \*schedules.csv, refactor
 
         Description:
         Remove duplicate measure code.
-        Catch *schedules.csv since OS-HPXML generates in.schedules.csv.
+        Catch \*schedules.csv since OS-HPXML generates in.schedules.csv.
         Remove "retain_in_idf: false" from national project yml files; appears that even if you delete in.idf from ServerDirectoryCleanup, the file is still subsequently exported (by the openstudio workflow?).
 
         Assignees: Joe Robertson

--- a/docs/read_the_docs/source/changelog/changelog_dev.rst
+++ b/docs/read_the_docs/source/changelog/changelog_dev.rst
@@ -7,6 +7,23 @@ Development Changelog
     :released: pending
 
     .. change::
+        :tags: workflow, refactor, bugfix
+        :pullreq: 1277
+
+        **Date**: 2024-07-22
+
+        Title:
+        ServerDirectoryCleanup: catch *schedules.csv, refactor
+
+        Description:
+        Remove duplicate measure code.
+        Catch *schedules.csv since OS-HPXML generates in.schedules.csv.
+        Remove "retain_in_idf: false" from national project yml files; appears that even if you delete in.idf from ServerDirectoryCleanup, the file is still subsequently exported (by the openstudio workflow?).
+
+        Assignees: Joe Robertson
+
+
+    .. change::
         :tags: workflow, mechanics, feature
         :pullreq: 1275
 

--- a/measures/ServerDirectoryCleanup/README.md
+++ b/measures/ServerDirectoryCleanup/README.md
@@ -6,7 +6,7 @@
 ## Description
 Optionally removes a significant portion of the saved results from each run, helping to alleviate memory problems.
 
-Present a bunch of bool arguments corresponding to EnergyPlus output files. "False" deletes the file, and "True" retains it. Most arguments default to not retaining the file. Only the in.idf and schedules.csv are retained by default.
+Present a bunch of bool arguments corresponding to EnergyPlus output files. "False" deletes the file, and "True" retains it. Most arguments default to not retaining the file. Only the in.idf and *schedules.csv are retained by default.
 
 ## Arguments
 

--- a/measures/ServerDirectoryCleanup/README.md
+++ b/measures/ServerDirectoryCleanup/README.md
@@ -154,7 +154,7 @@ Present a bunch of bool arguments corresponding to EnergyPlus output files. "Fal
 
 <br/>
 
-**Retain eplusout.msgpack**
+**Retain eplusout*.msgpack**
 
 
 
@@ -187,7 +187,7 @@ Present a bunch of bool arguments corresponding to EnergyPlus output files. "Fal
 
 <br/>
 
-**Retain stdout-expandobject.**
+**Retain stdout-expandobject**
 
 
 
@@ -198,7 +198,7 @@ Present a bunch of bool arguments corresponding to EnergyPlus output files. "Fal
 
 <br/>
 
-**Retain schedules.csv.**
+**Retain *schedules.csv**
 
 
 

--- a/measures/ServerDirectoryCleanup/measure.rb
+++ b/measures/ServerDirectoryCleanup/measure.rb
@@ -18,7 +18,7 @@ class ServerDirectoryCleanup < OpenStudio::Measure::ReportingMeasure
 
   # human readable description of modeling approach
   def modeler_description
-    return 'Present a bunch of bool arguments corresponding to EnergyPlus output files. "False" deletes the file, and "True" retains it. Most arguments default to not retaining the file. Only the in.idf and schedules.csv are retained by default.'
+    return 'Present a bunch of bool arguments corresponding to EnergyPlus output files. "False" deletes the file, and "True" retains it. Most arguments default to not retaining the file. Only the in.idf and *schedules.csv are retained by default.'
   end
 
   # define the arguments that the user will input

--- a/measures/ServerDirectoryCleanup/measure.rb
+++ b/measures/ServerDirectoryCleanup/measure.rb
@@ -91,7 +91,7 @@ class ServerDirectoryCleanup < OpenStudio::Measure::ReportingMeasure
     args << arg
 
     arg = OpenStudio::Measure::OSArgument.makeBoolArgument('retain_eplusout_msgpack', true)
-    arg.setDisplayName('Retain eplusout.msgpack')
+    arg.setDisplayName('Retain eplusout*.msgpack')
     arg.setDefaultValue(false)
     args << arg
 
@@ -106,12 +106,12 @@ class ServerDirectoryCleanup < OpenStudio::Measure::ReportingMeasure
     args << arg
 
     arg = OpenStudio::Measure::OSArgument.makeBoolArgument('retain_stdout_expandobject', true)
-    arg.setDisplayName('Retain stdout-expandobject.')
+    arg.setDisplayName('Retain stdout-expandobject')
     arg.setDefaultValue(false)
     args << arg
 
     arg = OpenStudio::Measure::OSArgument.makeBoolArgument('retain_schedules_csv', true)
-    arg.setDisplayName('Retain schedules.csv.')
+    arg.setDisplayName('Retain *schedules.csv')
     arg.setDefaultValue(true)
     args << arg
 
@@ -140,104 +140,47 @@ class ServerDirectoryCleanup < OpenStudio::Measure::ReportingMeasure
       return false
     end
 
-    in_osm = runner.getBoolArgumentValue('retain_in_osm', user_arguments)
-    in_idf = runner.getBoolArgumentValue('retain_in_idf', user_arguments)
-    pre_process_idf = runner.getBoolArgumentValue('retain_pre_process_idf', user_arguments)
-    eplusout_audit = runner.getBoolArgumentValue('retain_eplusout_audit', user_arguments)
-    eplusout_bnd = runner.getBoolArgumentValue('retain_eplusout_bnd', user_arguments)
-    eplusout_eio = runner.getBoolArgumentValue('retain_eplusout_eio', user_arguments)
-    eplusout_end = runner.getBoolArgumentValue('retain_eplusout_end', user_arguments)
-    eplusout_err = runner.getBoolArgumentValue('retain_eplusout_err', user_arguments)
-    eplusout_eso = runner.getBoolArgumentValue('retain_eplusout_eso', user_arguments)
-    eplusout_mdd = runner.getBoolArgumentValue('retain_eplusout_mdd', user_arguments)
-    eplusout_mtd = runner.getBoolArgumentValue('retain_eplusout_mtd', user_arguments)
-    eplusout_rdd = runner.getBoolArgumentValue('retain_eplusout_rdd', user_arguments)
-    eplusout_shd = runner.getBoolArgumentValue('retain_eplusout_shd', user_arguments)
-    eplusout_msgpack = runner.getBoolArgumentValue('retain_eplusout_msgpack', user_arguments)
-    eplustbl_htm = runner.getBoolArgumentValue('retain_eplustbl_htm', user_arguments)
-    stdout_energyplus = runner.getBoolArgumentValue('retain_stdout_energyplus', user_arguments)
-    stdout_expandobject = runner.getBoolArgumentValue('retain_stdout_expandobject', user_arguments)
-    schedules_csv = runner.getBoolArgumentValue('retain_schedules_csv', user_arguments)
-    debug = runner.getBoolArgumentValue('debug', user_arguments)
+    # assign the user inputs to variables
+    args = runner.getArgumentValues(arguments(model), user_arguments)
 
-    if debug
-      in_osm = in_idf = pre_process_idf = eplusout_audit = eplusout_bnd = eplusout_eio = eplusout_end = eplusout_err = eplusout_eso = eplusout_mdd = eplusout_mtd = eplusout_rdd = eplusout_shd = eplusout_msgpack = eplustbl_htm = stdout_energyplus = stdout_expandobject = schedules_csv = true
+    # retain everything if debug is true
+    if !args[:debug].nil? && args[:debug]
+      args.each do |arg_name, _value|
+        args[arg_name] = true
+      end
     end
 
-    Dir.glob('./../in.osm').each do |f|
-      File.delete(f) unless in_osm
-      runner.registerInfo("Deleted #{f} from the run directory.") if !File.exist?(f)
-    end
-    Dir.glob('./../in.idf').each do |f|
-      File.delete(f) unless in_idf
-      runner.registerInfo("Deleted #{f} from the run directory.") if !File.exist?(f)
-    end
-    Dir.glob('./../pre-preprocess.idf').each do |f|
-      File.delete(f) unless pre_process_idf
-      runner.registerInfo("Deleted #{f} from the run directory.") if !File.exist?(f)
-    end
-    Dir.glob('./../eplusout.audit').each do |f|
-      File.delete(f) unless eplusout_audit
-      runner.registerInfo("Deleted #{f} from the run directory.") if !File.exist?(f)
-    end
-    Dir.glob('./../eplusout.bnd').each do |f|
-      File.delete(f) unless eplusout_bnd
-      runner.registerInfo("Deleted #{f} from the run directory.") if !File.exist?(f)
-    end
-    Dir.glob('./../eplusout.eio').each do |f|
-      File.delete(f) unless eplusout_eio
-      runner.registerInfo("Deleted #{f} from the run directory.") if !File.exist?(f)
-    end
-    Dir.glob('./../eplusout.end').each do |f|
-      File.delete(f) unless eplusout_end
-      runner.registerInfo("Deleted #{f} from the run directory.") if !File.exist?(f)
-    end
-    Dir.glob('./../eplusout.err').each do |f|
-      File.delete(f) unless eplusout_err
-      runner.registerInfo("Deleted #{f} from the run directory.") if !File.exist?(f)
-    end
-    Dir.glob('./../eplusout.eso').each do |f|
-      File.delete(f) unless eplusout_eso
-      runner.registerInfo("Deleted #{f} from the run directory.") if !File.exist?(f)
-    end
-    Dir.glob('./../eplusout.mdd').each do |f|
-      File.delete(f) unless eplusout_mdd
-      runner.registerInfo("Deleted #{f} from the run directory.") if !File.exist?(f)
-    end
-    Dir.glob('./../eplusout.mtd').each do |f|
-      File.delete(f) unless eplusout_mtd
-      runner.registerInfo("Deleted #{f} from the run directory.") if !File.exist?(f)
-    end
-    Dir.glob('./../eplusout.rdd').each do |f|
-      File.delete(f) unless eplusout_rdd
-      runner.registerInfo("Deleted #{f} from the run directory.") if !File.exist?(f)
-    end
-    Dir.glob('./../eplusout.shd').each do |f|
-      File.delete(f) unless eplusout_shd
-      runner.registerInfo("Deleted #{f} from the run directory.") if !File.exist?(f)
-    end
-    Dir.glob('./../eplusout*.msgpack').each do |f|
-      File.delete(f) unless eplusout_msgpack
-      runner.registerInfo("Deleted #{f} from the run directory.") if !File.exist?(f)
-    end
-    Dir.glob('./../eplustbl.htm').each do |f|
-      File.delete(f) unless eplustbl_htm
-      runner.registerInfo("Deleted #{f} from the run directory.") if !File.exist?(f)
-    end
-    Dir.glob('./../stdout-energyplus').each do |f|
-      File.delete(f) unless stdout_energyplus
-      runner.registerInfo("Deleted #{f} from the run directory.") if !File.exist?(f)
-    end
-    Dir.glob('./../stdout-expandobject').each do |f|
-      File.delete(f) unless stdout_expandobject
-      runner.registerInfo("Deleted #{f} from the run directory.") if !File.exist?(f)
-    end
-    Dir.glob('./../schedules.csv').each do |f|
-      File.delete(f) unless schedules_csv
-      runner.registerInfo("Deleted #{f} from the run directory.") if !File.exist?(f)
+    # construct an argument name to file(s) map
+    arg_name_to_file = {
+      :retain_in_osm => 'in.osm',
+      :retain_in_idf => 'in.idf',
+      :retain_pre_process_idf => 'pre-preprocess.idf',
+      :retain_eplusout_audit => 'eplusout.audit',
+      :retain_eplusout_bnd => 'eplusout.bnd',
+      :retain_eplusout_eio => 'eplusout.eio',
+      :retain_eplusout_end => 'eplusout.end',
+      :retain_eplusout_err => 'eplusout.err',
+      :retain_eplusout_eso => 'eplusout.eso',
+      :retain_eplusout_mdd => 'eplusout.mdd',
+      :retain_eplusout_mtd => 'eplusout.mtd',
+      :retain_eplusout_rdd => 'eplusout.rdd',
+      :retain_eplusout_shd => 'eplusout.shd',
+      :retain_eplusout_msgpack => 'eplusout*.msgpack',
+      :retain_eplustbl_htm => 'eplustbl.htm',
+      :retain_stdout_energyplus => 'stdout-energyplus',
+      :retain_stdout_expandobject => 'stdout-expandobject',
+      :retain_schedules_csv => '*schedules.csv'
+    }
+
+    # delete output files based on the map
+    arg_name_to_file.each do |arg_name, file|
+      Dir.glob("./../#{file}").each do |f|
+        File.delete(f) if !args[arg_name]
+        runner.registerInfo("Deleted #{f} from the run directory.") if !File.exist?(f)
+      end
     end
 
-    true
+    return true
   end # end the run method
 end # end the measure
 

--- a/measures/ServerDirectoryCleanup/measure.xml
+++ b/measures/ServerDirectoryCleanup/measure.xml
@@ -3,13 +3,13 @@
   <schema_version>3.1</schema_version>
   <name>server_directory_cleanup</name>
   <uid>ec7d04ad-0b7b-495b-825a-e1b6d28d1d3f</uid>
-  <version_id>32b7cd1b-2747-445d-b4d7-8d634b4bcc40</version_id>
-  <version_modified>2024-07-22T17:12:23Z</version_modified>
+  <version_id>f7340639-5863-4725-8fc3-73f9f0e2131e</version_id>
+  <version_modified>2024-07-22T19:32:23Z</version_modified>
   <xml_checksum>5F1EDF75</xml_checksum>
   <class_name>ServerDirectoryCleanup</class_name>
   <display_name>Server Directory Cleanup</display_name>
   <description>Optionally removes a significant portion of the saved results from each run, helping to alleviate memory problems.</description>
-  <modeler_description>Present a bunch of bool arguments corresponding to EnergyPlus output files. "False" deletes the file, and "True" retains it. Most arguments default to not retaining the file. Only the in.idf and schedules.csv are retained by default.</modeler_description>
+  <modeler_description>Present a bunch of bool arguments corresponding to EnergyPlus output files. "False" deletes the file, and "True" retains it. Most arguments default to not retaining the file. Only the in.idf and *schedules.csv are retained by default.</modeler_description>
   <arguments>
     <argument>
       <name>retain_in_osm</name>
@@ -377,7 +377,7 @@
       <filename>README.md</filename>
       <filetype>md</filetype>
       <usage_type>readme</usage_type>
-      <checksum>B7F7E120</checksum>
+      <checksum>75515703</checksum>
     </file>
     <file>
       <filename>README.md.erb</filename>
@@ -394,7 +394,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>36C8DA75</checksum>
+      <checksum>43919C01</checksum>
     </file>
   </files>
 </measure>

--- a/measures/ServerDirectoryCleanup/measure.xml
+++ b/measures/ServerDirectoryCleanup/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>server_directory_cleanup</name>
   <uid>ec7d04ad-0b7b-495b-825a-e1b6d28d1d3f</uid>
-  <version_id>0187da15-5c10-4a11-86d0-40696236d4ac</version_id>
-  <version_modified>2023-11-27T22:10:39Z</version_modified>
+  <version_id>32b7cd1b-2747-445d-b4d7-8d634b4bcc40</version_id>
+  <version_modified>2024-07-22T17:12:23Z</version_modified>
   <xml_checksum>5F1EDF75</xml_checksum>
   <class_name>ServerDirectoryCleanup</class_name>
   <display_name>Server Directory Cleanup</display_name>
@@ -247,7 +247,7 @@
     </argument>
     <argument>
       <name>retain_eplusout_msgpack</name>
-      <display_name>Retain eplusout.msgpack</display_name>
+      <display_name>Retain eplusout*.msgpack</display_name>
       <type>Boolean</type>
       <required>true</required>
       <model_dependent>false</model_dependent>
@@ -301,7 +301,7 @@
     </argument>
     <argument>
       <name>retain_stdout_expandobject</name>
-      <display_name>Retain stdout-expandobject.</display_name>
+      <display_name>Retain stdout-expandobject</display_name>
       <type>Boolean</type>
       <required>true</required>
       <model_dependent>false</model_dependent>
@@ -319,7 +319,7 @@
     </argument>
     <argument>
       <name>retain_schedules_csv</name>
-      <display_name>Retain schedules.csv.</display_name>
+      <display_name>Retain *schedules.csv</display_name>
       <type>Boolean</type>
       <required>true</required>
       <model_dependent>false</model_dependent>
@@ -377,7 +377,7 @@
       <filename>README.md</filename>
       <filetype>md</filetype>
       <usage_type>readme</usage_type>
-      <checksum>93DECA02</checksum>
+      <checksum>B7F7E120</checksum>
     </file>
     <file>
       <filename>README.md.erb</filename>
@@ -394,7 +394,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>D28657CE</checksum>
+      <checksum>36C8DA75</checksum>
     </file>
   </files>
 </measure>

--- a/project_national/national_baseline.yml
+++ b/project_national/national_baseline.yml
@@ -53,7 +53,6 @@ workflow_generator:
       - measure_dir_name: QOIReport
 
     server_directory_cleanup:
-      retain_in_idf: false
       retain_schedules_csv: false
 
 baseline:

--- a/project_national/national_upgrades.yml
+++ b/project_national/national_upgrades.yml
@@ -53,7 +53,6 @@ workflow_generator:
       - measure_dir_name: QOIReport
 
     server_directory_cleanup:
-      retain_in_idf: false
       retain_schedules_csv: false
 
 baseline:


### PR DESCRIPTION
## Pull Request Description

Remove duplicate measure code.
Catch `*schedules.csv` since OS-HPXML generates `in.schedules.csv`.
Remove `retain_in_idf: false` from national project yml files; appears that even if you delete `in.idf` from ServerDirectoryCleanup, the file is still subsequently exported (by the openstudio workflow?).

## Checklist

Not all may apply:

- [x] Tests (and test files) have been updated
- [x] Documentation has been updated
  - [ ] ~If related to resstock-estimation, checklist includes [data dictionary](https://github.com/NREL/resstock/tree/develop/resources/data/dictionary), [source report](https://github.com/NREL/resstock/tree/develop/project_national/resources/source_report.csv), [options saturation](https://github.com/NREL/resstock/tree/develop/project_national/resources/options_saturations.csv), [options_lookup](https://github.com/NREL/resstock/blob/develop/resources/options_lookup.tsv).~
- [x] Add to the [changelog_dev.rst file](https://github.com/NREL/resstock/tree/develop/docs/read_the_docs/source/changelog/changelog_dev.rst)
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected regression test changes on CI (checked comparison artifacts)
