### PR TITLE
Break out Mobile Home in CI comparison plots

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -281,37 +281,25 @@ jobs:
           pip install plotly
           pip install kaleido
           
-          mkdir test/base_results/comparisons
+          # baseline annual
+          mkdir -p test/base_results/comparisons/baseline/annual
+          python test/compare.py -a samples -b base_results/baseline/annual -f samples -e test/base_results/comparisons/baseline/annual # base_samples.csv, feature_samples.csv
+          python test/compare.py -a results -b base_results/baseline/annual -f results/baseline/annual -e test/base_results/comparisons/baseline/annual # results_characteristics.csv, results_output.csv
+          python test/compare.py -a results -af sum -ac build_existing_model.geometry_building_type_recs -x results_output_building_type_sum.csv -b base_results/baseline/annual -f results/baseline/annual -e test/base_results/comparisons/baseline/annual # results_output_building_type_sum.csv
+          python test/compare.py -a visualize -dc build_existing_model.geometry_building_type_recs -x results_output_building_type.html -b base_results/baseline/annual -f results/baseline/annual -e test/base_results/comparisons/baseline/annual # *.html
           
-          mkdir test/base_results/comparisons/baseline
-          
-          mkdir test/base_results/comparisons/baseline/annual
-          
-          python test/compare.py -a samples -b base_results/baseline/annual -f samples -e test/base_results/comparisons/baseline/annual
-                    
-          python test/compare.py -a results -b base_results/baseline/annual -f results/baseline/annual -e test/base_results/comparisons/baseline/annual
-          python test/compare.py -a results -af sum -ac build_existing_model.geometry_building_type_recs -x results_output_building_type_sum.csv -b base_results/baseline/annual -f results/baseline/annual -e test/base_results/comparisons/baseline/annual
-          
-          python test/compare.py -a visualize -dc build_existing_model.geometry_building_type_recs -x results_output_building_type.html -b base_results/baseline/annual -f results/baseline/annual -e test/base_results/comparisons/baseline/annual
-          # python test/compare.py -a visualize -dc build_existing_model.geometry_foundation_type -x results_output_foundation_type.html -b base_results/baseline/annual -f results/baseline/annual -e test/base_results/comparisons/baseline/annual
-          # python test/compare.py -a visualize -dc build_existing_model.census_region -x results_output_cr.html -b base_results/baseline/annual -f results/baseline/annual -e test/base_results/comparisons/baseline/annual
-          # python test/compare.py -a visualize -dc build_existing_model.geometry_building_type_recs -ac build_existing_model.census_region -af sum -x results_output_cr_sum.html -b base_results/baseline/annual -f results/baseline/annual -e test/base_results/comparisons/baseline/annual
-          
+          # baseline timeseries
           mkdir test/base_results/comparisons/baseline/timeseries
-                    
-          python test/compare.py -a timeseries -b base_results/baseline/timeseries -f results/baseline/timeseries -e test/base_results/comparisons/baseline/timeseries
+          python test/compare.py -a timeseries -b base_results/baseline/timeseries -f results/baseline/timeseries -e test/base_results/comparisons/baseline/timeseries # cvrmse_nmbe_*.csv
           
-          mkdir test/base_results/comparisons/upgrades
+          # upgrades annual
+          mkdir -p test/base_results/comparisons/upgrades/annual
+          python test/compare.py -a results -b base_results/upgrades/annual -f results/upgrades/annual -e test/base_results/comparisons/upgrades/annual # results_output.csv
+          python test/compare.py -a visualize -x results_output.html -b base_results/upgrades/annual -f results/upgrades/annual -e test/base_results/comparisons/upgrades/annual # *.html
           
-          mkdir test/base_results/comparisons/upgrades/annual
-                    
-          python test/compare.py -a results -b base_results/upgrades/annual -f results/upgrades/annual -e test/base_results/comparisons/upgrades/annual
-          
-          python test/compare.py -a visualize -x results_output.html -b base_results/upgrades/annual -f results/upgrades/annual -e test/base_results/comparisons/upgrades/annual
-          
+          # upgrades timeseries
           mkdir test/base_results/comparisons/upgrades/timeseries
-                    
-          python test/compare.py -a timeseries -b base_results/upgrades/timeseries -f results/upgrades/timeseries -e test/base_results/comparisons/upgrades/timeseries
+          python test/compare.py -a timeseries -b base_results/upgrades/timeseries -f results/upgrades/timeseries -e test/base_results/comparisons/upgrades/timeseries # cvrmse_nmbe_*.csv
 
       - name: Upload comparisons
         uses: actions/upload-artifact@v4

--- a/test/compare.py
+++ b/test/compare.py
@@ -12,7 +12,7 @@ from compare import BaseCompare, read_csv
 
 
 enum_maps = {'build_existing_model.geometry_building_type_recs': {'Single-Family Detached': 'SFD',
-                                                                  'Mobile Home': 'SFD',
+                                                                  'Mobile Home': 'MH',
                                                                   'Single-Family Attached': 'SFA',
                                                                   'Multi-Family with 2 - 4 Units': 'MF',
                                                                   'Multi-Family with 5+ Units': 'MF'} }

--- a/test/compare.py
+++ b/test/compare.py
@@ -11,11 +11,11 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.abspath(__file__), '../.
 from compare import BaseCompare, read_csv
 
 
-enum_maps = {'build_existing_model.geometry_building_type_recs': {'Single-Family Detached': 'SFD',
-                                                                  'Mobile Home': 'MH',
-                                                                  'Single-Family Attached': 'SFA',
-                                                                  'Multi-Family with 2 - 4 Units': 'MF',
-                                                                  'Multi-Family with 5+ Units': 'MF'} }
+enum_maps = {'build_existing_model.geometry_building_type_recs': {'Single-Family Detached': '1 - SFD',
+                                                                  'Mobile Home': '2 - MH',
+                                                                  'Single-Family Attached': '3 - SFA',
+                                                                  'Multi-Family with 2 - 4 Units': '4 - MF',
+                                                                  'Multi-Family with 5+ Units': '4 - MF'} }
 
 class MoreCompare(BaseCompare):
   def __init__(self, base_folder, feature_folder, export_folder, export_file, map_file):

--- a/test/compare.py
+++ b/test/compare.py
@@ -11,11 +11,11 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.abspath(__file__), '../.
 from compare import BaseCompare, read_csv
 
 
-enum_maps = {'build_existing_model.geometry_building_type_recs': {'Single-Family Detached': '1 - SFD',
-                                                                  'Mobile Home': '2 - MH',
-                                                                  'Single-Family Attached': '3 - SFA',
-                                                                  'Multi-Family with 2 - 4 Units': '4 - MF',
-                                                                  'Multi-Family with 5+ Units': '4 - MF'} }
+enum_maps = {'build_existing_model.geometry_building_type_recs': {'Single-Family Detached': 'SFD',
+                                                                  'Mobile Home': 'MH',
+                                                                  'Single-Family Attached': 'SFA',
+                                                                  'Multi-Family with 2 - 4 Units': 'MF',
+                                                                  'Multi-Family with 5+ Units': 'MF'} }
 
 class MoreCompare(BaseCompare):
   def __init__(self, base_folder, feature_folder, export_folder, export_file, map_file):


### PR DESCRIPTION
## Pull Request Description

Closes #1285.

![image](https://github.com/user-attachments/assets/d1854dae-b849-45dd-b7e5-d7d1d1d6e747)

## Checklist

Not all may apply:

- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
  - [ ] If related to resstock-estimation, checklist includes [data dictionary](https://github.com/NREL/resstock/tree/develop/resources/data/dictionary), [source report](https://github.com/NREL/resstock/tree/develop/project_national/resources/source_report.csv), [options saturation](https://github.com/NREL/resstock/tree/develop/project_national/resources/options_saturations.csv), [options_lookup](https://github.com/NREL/resstock/blob/develop/resources/options_lookup.tsv).
- [ ] Add to the [changelog_dev.rst file](https://github.com/NREL/resstock/tree/develop/docs/read_the_docs/source/changelog/changelog_dev.rst)
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
