### PR TITLE
ResStockArguments: fix pv/battery present bool args

### DIFF
--- a/measures/ResStockArguments/measure.rb
+++ b/measures/ResStockArguments/measure.rb
@@ -480,14 +480,14 @@ class ResStockArguments < OpenStudio::Measure::ModelMeasure
     end
 
     # PV
-    if args[:pv_system_present] == 'true'
+    if args[:pv_system_present]
       args[:pv_system_num_bedrooms_served] = args[:geometry_unit_num_bedrooms]
     else
       args[:pv_system_num_bedrooms_served] = 0
     end
 
     # Battery
-    if args[:battery_present] == 'true'
+    if args[:battery_present]
       args[:battery_num_bedrooms_served] = args[:geometry_unit_num_bedrooms]
     else
       args[:battery_num_bedrooms_served] = 0

--- a/measures/ResStockArguments/measure.xml
+++ b/measures/ResStockArguments/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>res_stock_arguments</name>
   <uid>c984bb9e-4ac4-4930-a399-9d23f8f6936a</uid>
-  <version_id>13eb1e73-e190-422f-b871-d681c4629b43</version_id>
-  <version_modified>2024-07-19T23:49:15Z</version_modified>
+  <version_id>96391061-ab5b-40a9-9c48-24e5c9b3dc5d</version_id>
+  <version_modified>2024-08-26T18:27:48Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>ResStockArguments</class_name>
   <display_name>ResStock Arguments</display_name>
@@ -7535,7 +7535,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>4D84A86B</checksum>
+      <checksum>32EB14D4</checksum>
     </file>
     <file>
       <filename>constants.rb</filename>


### PR DESCRIPTION
## Pull Request Description

Arguments `pv_system_present` and `battery_present` are bools, not strings. But since we were never setting `xxx_num_bedrooms_served` greater than `geometry_unit_num_bedrooms` anyway, I believe this issue was inconsequential.

## Checklist

Not all may apply:

- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
  - [ ] If related to resstock-estimation, checklist includes [data dictionary](https://github.com/NREL/resstock/tree/develop/resources/data/dictionary), [source report](https://github.com/NREL/resstock/tree/develop/project_national/resources/source_report.csv), [options saturation](https://github.com/NREL/resstock/tree/develop/project_national/resources/options_saturations.csv), [options_lookup](https://github.com/NREL/resstock/blob/develop/resources/options_lookup.tsv).
- [ ] Add to the [changelog_dev.rst file](https://github.com/NREL/resstock/tree/develop/docs/read_the_docs/source/changelog/changelog_dev.rst)
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
