### PR TITLE
Pin ubuntu runner version in CI for stability

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   add-to-project:
     name: Add pull request or issue to project
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/add-to-project@v1.0.0
         with:

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   format-files:
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -35,7 +35,7 @@ jobs:
           name: options_lookup
 
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [format-files]
     container:
       image: docker://nrel/openstudio:3.8.0
@@ -79,7 +79,7 @@ jobs:
           name: coverage
 
   analysis-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [unit-tests]
     container:
       image: docker://nrel/openstudio:3.8.0
@@ -135,7 +135,7 @@ jobs:
           name: run_analysis_results_csvs
 
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [unit-tests]
     steps:
       - uses: actions/checkout@v4
@@ -211,7 +211,7 @@ jobs:
           ruby test/test_bsb_analysis.rb
 
   compare-tools:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [analysis-tests, integration-tests]
     steps:
       - uses: actions/checkout@v4
@@ -239,7 +239,7 @@ jobs:
 
   compare-results:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [integration-tests]
     steps:
       - uses: actions/checkout@v4
@@ -308,7 +308,7 @@ jobs:
           name: comparisons
 
   update-results:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [analysis-tests, integration-tests]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Pull Request Description
Our CI is failing due to ubunut-latest being recently updated to Ubuntu 24.04.  This PR pins ubuntu version to 22.04 - a version that has been working for us so far.

### Related Pull Requests
[related PRs from different repositories]

### Related Issues
CI is failing when trying to install buildstockbatch on system python. 
Error:
```
Run pip install git+https://github.com/NREL/buildstockbatch.git@develop
  pip install git+https://github.com/NREL/buildstockbatch.git@develop
  
  buildstock_local project_national/national_baseline.yml
  buildstock_local project_testing/testing_baseline.yml
  
  buildstock_local project_national/national_upgrades.yml
  buildstock_local project_testing/testing_upgrades.yml
  shell: /usr/bin/bash -e {0}
  env:
    OPENSTUDIO_VER: 3.8.0
    OPENSTUDIO_SHA: f953b6fcaf
    OPENSTUDIO_PLATFORM: Ubuntu-[2](https://github.com/NREL/resstock/actions/runs/11335475928/job/31524166324?pr=929#step:5:2)0.04-x86_64
    OPENSTUDIO_EXT: deb
    OPENSTUDIO_URL: https://github.com/NREL/OpenStudio/releases/download/v[3](https://github.com/NREL/resstock/actions/runs/11335475928/job/31524166324?pr=929#step:5:3).8.0
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP [6](https://github.com/NREL/resstock/actions/runs/11335475928/job/31524166324?pr=929#step:5:6)68 for the detailed specification.
Error: Process completed with exit code 1.
```

## Checklist

#### Required:
- [ ] [Technical reference documentation](https://github.com/NREL/resstock/tree/develop/docs/read_the_docs) has been updated
- [ ] Add to the [changelog_dev.rst file](https://github.com/NREL/resstock/tree/develop/docs/read_the_docs/source/changelog/changelog_dev.rst)
- [ ] No unexpected regression test changes on CI (comparison artifacts have been checked)

#### Optional (not all items may apply):
- [ ] Tests (and test files) have been updated
- [ ] Supporting resource files have been updated (related to resstock-estimation)
  - [ ] [data dictionary](https://github.com/NREL/resstock/tree/develop/resources/data/dictionary)
  - [ ] [source report](https://github.com/NREL/resstock/tree/develop/project_national/resources/source_report.csv)
  - [ ] [options saturation](https://github.com/NREL/resstock/tree/develop/project_national/resources/options_saturations.csv)
  - [ ] [options_lookup](https://github.com/NREL/resstock/blob/develop/resources/options_lookup.tsv)
- [ ] `openstudio tasks.rb update_measures` has been run